### PR TITLE
Feature/12 카테고리 조회

### DIFF
--- a/src/main/java/org/kakaoshare/backend/common/config/QuerydslConfiguration.java
+++ b/src/main/java/org/kakaoshare/backend/common/config/QuerydslConfiguration.java
@@ -1,0 +1,17 @@
+package org.kakaoshare.backend.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfiguration {
+    @PersistenceContext
+    private EntityManager entityManager;
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/brand/dto/TabType.java
+++ b/src/main/java/org/kakaoshare/backend/domain/brand/dto/TabType.java
@@ -1,0 +1,5 @@
+package org.kakaoshare.backend.domain.brand.dto;
+
+public enum TabType {
+    ALL,BRAND,PRODUCT
+}

--- a/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
@@ -1,6 +1,7 @@
 package org.kakaoshare.backend.domain.category.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.kakaoshare.backend.domain.brand.dto.TabType;
 import org.kakaoshare.backend.domain.category.entity.Category;
@@ -17,6 +18,7 @@ public class CategoryDto {
     private final List<CategoryDto> subCategories = new ArrayList<>();
     private final TabType defaultTab;
     
+    @Builder
     public CategoryDto(Long categoryId, String categoryName, Long parentId) {
         this.categoryId = categoryId;
         this.categoryName = categoryName;
@@ -24,11 +26,12 @@ public class CategoryDto {
         this.defaultTab = TabType.BRAND;//브랜드를 조회하는것이 화면 로딩과정에서 쿼리를 최소화 가능해보임
     }
     
-    public static CategoryDto of(Category category) {
-        return new CategoryDto(
-                category.getCategoryId(),
-                category.getName(),
-                category.getParent().getCategoryId());
+    public static CategoryDto from(final Category category) {
+        return CategoryDto.builder()
+                .categoryId(category.getCategoryId())
+                .categoryName(category.getName())
+                .parentId(category.getParent().getCategoryId())
+                .build();
     }
     
     @Override

--- a/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
@@ -2,7 +2,6 @@ package org.kakaoshare.backend.domain.category.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 import org.kakaoshare.backend.domain.brand.dto.TabType;
 import org.kakaoshare.backend.domain.category.entity.Category;
 
@@ -10,19 +9,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@Setter
 @AllArgsConstructor
 public class CategoryDto {
-    private Long categoryId;
-    private String categoryName;
-    private Long parentId;
-    private List<CategoryDto> subCategories=new ArrayList<>();
-    private TabType defaultTab;
+    private final Long categoryId;
+    private final String categoryName;
+    private final Long parentId;
+    private final List<CategoryDto> subCategories = new ArrayList<>();
+    private final TabType defaultTab;
     
-    public CategoryDto(Long categoryId, String categoryName,Long parentId) {
+    public CategoryDto(Long categoryId, String categoryName, Long parentId) {
         this.categoryId = categoryId;
         this.categoryName = categoryName;
-        this.parentId=parentId;
+        this.parentId = parentId;
         this.defaultTab = TabType.BRAND;//브랜드를 조회하는것이 화면 로딩과정에서 쿼리를 최소화 가능해보임
     }
     

--- a/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
@@ -7,7 +7,6 @@ import org.kakaoshare.backend.domain.brand.dto.TabType;
 import org.kakaoshare.backend.domain.category.entity.Category;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -15,7 +14,6 @@ import java.util.stream.Collectors;
 public class CategoryDto {
     private Long categoryId;
     private String categoryName;
-    private int level;
     private List<CategoryDto> subCategories;
     private TabType defaultTab;
     
@@ -30,7 +28,7 @@ public class CategoryDto {
         return new CategoryDto(
                 category.getCategoryId(),
                 category.getName(),
-                category.getChildren().stream().map(CategoryDto::of).collect(Collectors.toList()));
+                category.getChildren().stream()
+                        .map(CategoryDto::of).toList());
     }
-    
 }

--- a/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
@@ -1,0 +1,38 @@
+package org.kakaoshare.backend.domain.category.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.kakaoshare.backend.domain.brand.dto.TabType;
+import org.kakaoshare.backend.domain.category.entity.Category;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CategoryDto {
+    private Long categoryId;
+    private String categoryName;
+    private int level;
+    private List<CategoryDto> subCategories;
+    private TabType defaultTab;
+    
+    public CategoryDto(Long categoryId, String categoryName, int level, List<CategoryDto> subCategories) {
+        this.categoryId = categoryId;
+        this.categoryName = categoryName;
+        this.level = level;
+        this.subCategories = subCategories;
+        this.defaultTab = TabType.BRAND;//브랜드를 조회하는것이 화면 로딩과정에서 쿼리를 최소화 가능해보임
+    }
+    
+    public static CategoryDto of(Category category) {
+        return new CategoryDto(
+                category.getCategoryId(),
+                category.getName(),
+                category.getLevel(),
+                category.getChildren().stream().map(CategoryDto::of).collect(Collectors.toList()));
+    }
+    
+}

--- a/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import org.kakaoshare.backend.domain.brand.dto.TabType;
 import org.kakaoshare.backend.domain.category.entity.Category;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -14,13 +15,14 @@ import java.util.List;
 public class CategoryDto {
     private Long categoryId;
     private String categoryName;
-    private List<CategoryDto> subCategories;
+    private Long parentId;
+    private List<CategoryDto> subCategories=new ArrayList<>();
     private TabType defaultTab;
     
-    public CategoryDto(Long categoryId, String categoryName, List<CategoryDto> subCategories) {
+    public CategoryDto(Long categoryId, String categoryName,Long parentId) {
         this.categoryId = categoryId;
         this.categoryName = categoryName;
-        this.subCategories = subCategories;
+        this.parentId=parentId;
         this.defaultTab = TabType.BRAND;//브랜드를 조회하는것이 화면 로딩과정에서 쿼리를 최소화 가능해보임
     }
     
@@ -28,7 +30,19 @@ public class CategoryDto {
         return new CategoryDto(
                 category.getCategoryId(),
                 category.getName(),
-                category.getChildren().stream()
-                        .map(CategoryDto::of).toList());
+                category.getParent().getCategoryId());
+    }
+    
+    @Override
+    public String toString() {
+        return "CategoryDto{" +
+                "categoryId=" + categoryId +
+                ", categoryName='" + categoryName + '\'' +
+                ", subCategory id=" +
+                subCategories.stream()
+                        .map(CategoryDto::getCategoryId)
+                        .toList() +
+                ", defaultTab=" + defaultTab +
+                '}';
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
@@ -19,10 +19,9 @@ public class CategoryDto {
     private List<CategoryDto> subCategories;
     private TabType defaultTab;
     
-    public CategoryDto(Long categoryId, String categoryName, int level, List<CategoryDto> subCategories) {
+    public CategoryDto(Long categoryId, String categoryName, List<CategoryDto> subCategories) {
         this.categoryId = categoryId;
         this.categoryName = categoryName;
-        this.level = level;
         this.subCategories = subCategories;
         this.defaultTab = TabType.BRAND;//브랜드를 조회하는것이 화면 로딩과정에서 쿼리를 최소화 가능해보임
     }
@@ -31,7 +30,6 @@ public class CategoryDto {
         return new CategoryDto(
                 category.getCategoryId(),
                 category.getName(),
-                category.getLevel(),
                 category.getChildren().stream().map(CategoryDto::of).collect(Collectors.toList()));
     }
     

--- a/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
@@ -1,21 +1,19 @@
 package org.kakaoshare.backend.domain.category.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import java.util.List;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.kakaoshare.backend.domain.base.entity.BaseTimeEntity;
+
+import java.util.List;
 
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(staticName = "of")
 public class Category extends BaseTimeEntity {
 
     @Id
@@ -24,12 +22,15 @@ public class Category extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String name;
+    
+    @Column(nullable = false,updatable = false)
+    private Integer level;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Category parent;
 
     @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
-    private List<Category> Categories;
+    private List<Category> children;
 
 }

--- a/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
@@ -22,9 +22,6 @@ public class Category extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String name;
-    
-    @Column(nullable = false,updatable = false)
-    private Integer level;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")

--- a/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.kakaoshare.backend.domain.base.entity.BaseTimeEntity;
@@ -22,6 +23,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Category extends BaseTimeEntity {
@@ -40,16 +42,6 @@ public class Category extends BaseTimeEntity {
     
     @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Category> children;
-    
-    private Category(String name, Category parent, List<Category> children) {
-        this.name = name;
-        this.parent = parent;
-        this.children = children;
-    }
-    
-    public static Category of(String name, Category parent, List<Category> children) {
-        return new Category(name, parent, children);
-    }
     
     @Override
     public String toString() {

--- a/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
@@ -1,6 +1,16 @@
 package org.kakaoshare.backend.domain.category.entity;
 
-import jakarta.persistence.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,21 +23,44 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(staticName = "of")
+@AllArgsConstructor
 public class Category extends BaseTimeEntity {
-
+    
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
     private Long categoryId;
-
+    
     @Column(nullable = false)
     private String name;
-
+    
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_id")
+    @JoinColumn(name = "parent_id", referencedColumnName = "category_id")
     private Category parent;
-
-    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
+    
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Category> children;
-
+    
+    public Category(String name, Category parent, List<Category> children) {
+        this.name = name;
+        this.parent = parent;
+        this.children = children;
+    }
+    
+    public static Category of(String name, Category parent, List<Category> children) {
+        return new Category(name, parent, children);
+    }
+    
+    @Override
+    public String toString() {
+        return "Category{" + '\n' +
+                "categoryId=" + categoryId + '\n' +
+                ", name='" + name + '\n' +
+                ", parent id=" + parent.getCategoryId() + '\n' +
+                ", children id=" +
+                children.stream()
+                        .map(Category::getCategoryId)
+                        .toList() +
+                '}';
+    }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
@@ -41,7 +41,7 @@ public class Category extends BaseTimeEntity {
     @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Category> children;
     
-    public Category(String name, Category parent, List<Category> children) {
+    private Category(String name, Category parent, List<Category> children) {
         this.name = name;
         this.parent = parent;
         this.children = children;

--- a/src/main/java/org/kakaoshare/backend/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/repository/CategoryRepository.java
@@ -1,8 +1,9 @@
 package org.kakaoshare.backend.domain.category.repository;
 
 import org.kakaoshare.backend.domain.category.entity.Category;
+import org.kakaoshare.backend.domain.category.repository.query.CategoryRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
-public interface CategoryRepository extends JpaRepository<Category, Long> {
+public interface CategoryRepository extends JpaRepository<Category, Long>, CategoryRepositoryCustom {
 }

--- a/src/main/java/org/kakaoshare/backend/domain/category/repository/query/CategoryRepositoryCustom.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/repository/query/CategoryRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.kakaoshare.backend.domain.category.repository.query;
+
+import org.kakaoshare.backend.domain.category.entity.Category;
+
+import java.util.List;
+
+public interface CategoryRepositoryCustom {
+    List<Category> findAllWithChildren();
+}

--- a/src/main/java/org/kakaoshare/backend/domain/category/repository/query/CategoryRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/repository/query/CategoryRepositoryCustomImpl.java
@@ -8,7 +8,7 @@ import org.kakaoshare.backend.domain.category.entity.QCategory;
 import java.util.List;
 @RequiredArgsConstructor
 public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
-    private final JPAQueryFactory query;
+    private final JPAQueryFactory queryFactory;
 
 
     @Override
@@ -16,7 +16,7 @@ public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
         QCategory category = QCategory.category;
         QCategory child = new QCategory("child");
 
-        return query.selectFrom(category)
+        return queryFactory.selectFrom(category)
                 .leftJoin(category.children, child)
                 .fetchJoin()
                 .distinct()

--- a/src/main/java/org/kakaoshare/backend/domain/category/repository/query/CategoryRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/repository/query/CategoryRepositoryCustomImpl.java
@@ -1,0 +1,25 @@
+package org.kakaoshare.backend.domain.category.repository.query;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.domain.category.entity.Category;
+import org.kakaoshare.backend.domain.category.entity.QCategory;
+
+import java.util.List;
+@RequiredArgsConstructor
+public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
+    private final JPAQueryFactory query;
+
+
+    @Override
+    public List<Category> findAllWithChildren() {
+        QCategory category = QCategory.category;
+        QCategory child = new QCategory("child");
+
+        return query.selectFrom(category)
+                .leftJoin(category.children, child)
+                .fetchJoin()
+                .distinct()
+                .fetch();
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
@@ -37,7 +37,7 @@ public class CategoryService {
         Map<Long, List<CategoryDto>> childGroup = categories
                 .stream()
                 .filter(category -> Objects.nonNull(category.getParent()))
-                .map(CategoryDto::of)
+                .map(CategoryDto::from)
                 .collect(groupingBy(CategoryDto::getParentId));
         
         childGroup.forEach((parentId, subCategories) ->

--- a/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
@@ -19,7 +19,6 @@ public class CategoryService {
     public static final String ROOT_CATEGORY_NAME = "Root";
     private final CategoryRepository categoryRepository;
     
-    //TODO 2024 02 13 14:02:23 : 모든 카테고리 목록 조회
     
     public CategoryDto createCategoryRoot() {
         Map<Long, List<CategoryDto>> groupingByParentId = categoryRepository.findAllWithChildren()
@@ -27,14 +26,16 @@ public class CategoryService {
                 .map(CategoryDto::of)
                 .collect(groupingBy(CategoryDto::getCategoryId));
         
-        CategoryDto rootCategoryDto = new CategoryDto(0L, ROOT_CATEGORY_NAME, 0, null);
-        addSubCategories(rootCategoryDto, groupingByParentId,0);
+        CategoryDto rootCategoryDto = new CategoryDto(0L, ROOT_CATEGORY_NAME, null);
+        rootCategoryDto.setLevel(0);
+        addSubCategories(rootCategoryDto, groupingByParentId);
         
         return rootCategoryDto;
     }
     
-    private void addSubCategories(CategoryDto parent, Map<Long, List<CategoryDto>> categoryGroup,Integer level) {
-        if(level>= MAX_LEVEL)
+    private void addSubCategories(CategoryDto parent, Map<Long, List<CategoryDto>> categoryGroup) {
+        int level = parent.getLevel();
+        if(level >= MAX_LEVEL)
             return;
         List<CategoryDto> subCategories = categoryGroup.get(parent.getCategoryId());
         
@@ -42,6 +43,9 @@ public class CategoryService {
             return;
         parent.setSubCategories(subCategories);
         
-        subCategories.forEach(s -> addSubCategories(s, categoryGroup,level+1));
+        subCategories.forEach(s -> {
+            s.setLevel(level+1);
+            addSubCategories(s, categoryGroup);
+        });
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
@@ -1,0 +1,47 @@
+package org.kakaoshare.backend.domain.category.service;
+
+import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.domain.category.dto.CategoryDto;
+import org.kakaoshare.backend.domain.category.repository.CategoryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.groupingBy;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CategoryService {
+    public static final int MAX_LEVEL = 2;
+    public static final String ROOT_CATEGORY_NAME = "Root";
+    private final CategoryRepository categoryRepository;
+    
+    //TODO 2024 02 13 14:02:23 : 모든 카테고리 목록 조회
+    
+    public CategoryDto createCategoryRoot() {
+        Map<Long, List<CategoryDto>> groupingByParentId = categoryRepository.findAllWithChildren()
+                .stream()
+                .map(CategoryDto::of)
+                .collect(groupingBy(CategoryDto::getCategoryId));
+        
+        CategoryDto rootCategoryDto = new CategoryDto(0L, ROOT_CATEGORY_NAME, 0, null);
+        addSubCategories(rootCategoryDto, groupingByParentId,0);
+        
+        return rootCategoryDto;
+    }
+    
+    private void addSubCategories(CategoryDto parent, Map<Long, List<CategoryDto>> categoryGroup,Integer level) {
+        if(level>= MAX_LEVEL)
+            return;
+        List<CategoryDto> subCategories = categoryGroup.get(parent.getCategoryId());
+        
+        if (subCategories == null)
+            return;
+        parent.setSubCategories(subCategories);
+        
+        subCategories.forEach(s -> addSubCategories(s, categoryGroup,level+1));
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
@@ -40,14 +40,13 @@ public class CategoryService {
                 .map(CategoryDto::of)
                 .collect(groupingBy(CategoryDto::getParentId));
         
-        childGroup.forEach((parentId, subCategories) -> {
-            parentGroup.merge(parentId, subCategories, (existingSubCategories, newSubCategories) -> {
-                existingSubCategories.addAll(newSubCategories);
-                return existingSubCategories;
-            });
-        });
+        childGroup.forEach((parentId, subCategories) ->
+                parentGroup.merge(parentId, subCategories, (existingSubCategories, newSubCategories) -> {
+                    existingSubCategories.addAll(newSubCategories);
+                    return existingSubCategories;
+                }));
         
-        addSubCategories(rootCategoryDto,parentGroup);
+        addSubCategories(rootCategoryDto, parentGroup);
         
         return rootCategoryDto;
     }

--- a/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
@@ -2,12 +2,14 @@ package org.kakaoshare.backend.domain.category.service;
 
 import lombok.RequiredArgsConstructor;
 import org.kakaoshare.backend.domain.category.dto.CategoryDto;
+import org.kakaoshare.backend.domain.category.entity.Category;
 import org.kakaoshare.backend.domain.category.repository.CategoryRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.groupingBy;
 
@@ -15,37 +17,50 @@ import static java.util.stream.Collectors.groupingBy;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CategoryService {
-    public static final int MAX_LEVEL = 2;
-    public static final String ROOT_CATEGORY_NAME = "Root";
+    private static final String ROOT_CATEGORY_NAME = "Root";
     private final CategoryRepository categoryRepository;
     
     
     public CategoryDto createCategoryRoot() {
-        Map<Long, List<CategoryDto>> groupingByParentId = categoryRepository.findAllWithChildren()
-                .stream()
-                .map(CategoryDto::of)
-                .collect(groupingBy(CategoryDto::getCategoryId));
+        List<Category> categories = categoryRepository.findAllWithChildren();
+        CategoryDto rootCategoryDto = new CategoryDto(0L, ROOT_CATEGORY_NAME, 0L);
         
-        CategoryDto rootCategoryDto = new CategoryDto(0L, ROOT_CATEGORY_NAME, null);
-        rootCategoryDto.setLevel(0);
-        addSubCategories(rootCategoryDto, groupingByParentId);
+        Map<Long, List<CategoryDto>> parentGroup = categories
+                .stream()
+                .filter(category -> Objects.isNull(category.getParent()))
+                .map(category -> new CategoryDto(
+                        category.getCategoryId(),
+                        category.getName(),
+                        rootCategoryDto.getCategoryId()))//부모 ID를 Root로 임의 지정(DB에는 존재하지 않기 때문)
+                .collect(groupingBy(CategoryDto::getParentId));
+        
+        Map<Long, List<CategoryDto>> childGroup = categories
+                .stream()
+                .filter(category -> Objects.nonNull(category.getParent()))
+                .map(CategoryDto::of)
+                .collect(groupingBy(CategoryDto::getParentId));
+        
+        childGroup.forEach((parentId, subCategories) -> {
+            parentGroup.merge(parentId, subCategories, (existingSubCategories, newSubCategories) -> {
+                existingSubCategories.addAll(newSubCategories);
+                return existingSubCategories;
+            });
+        });
+        
+        addSubCategories(rootCategoryDto,parentGroup);
         
         return rootCategoryDto;
     }
     
     private void addSubCategories(CategoryDto parent, Map<Long, List<CategoryDto>> categoryGroup) {
-        int level = parent.getLevel();
-        if(level >= MAX_LEVEL)
-            return;
         List<CategoryDto> subCategories = categoryGroup.get(parent.getCategoryId());
         
-        if (subCategories == null)
+        if (subCategories == null) {
             return;
+        }
+        
         parent.setSubCategories(subCategories);
         
-        subCategories.forEach(s -> {
-            s.setLevel(level+1);
-            addSubCategories(s, categoryGroup);
-        });
+        subCategories.forEach(s -> addSubCategories(s, categoryGroup));
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
@@ -59,7 +59,7 @@ public class CategoryService {
             return;
         }
         
-        parent.setSubCategories(subCategories);
+        parent.getSubCategories().addAll(subCategories);
         
         subCategories.forEach(s -> addSubCategories(s, categoryGroup));
     }

--- a/src/test/java/org/kakaoshare/backend/domain/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/category/repository/CategoryRepositoryTest.java
@@ -1,0 +1,70 @@
+package org.kakaoshare.backend.domain.category.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kakaoshare.backend.domain.category.entity.Category;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class CategoryRepositoryTest {
+    @Autowired
+    private CategoryRepository categoryRepository;
+    
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        List<Category> categories = new ArrayList<>();
+        
+        Category rootCategory = Category.of(0L, "Root", 0, null, new ArrayList<>());
+        categories.add(rootCategory);
+        
+        for (int i = 1; i <= 5; i++) {
+            Category parentCategory = Category.of(0L, "Category " + i, 1, rootCategory, new ArrayList<>());
+            categories.add(parentCategory);
+            
+            for (int j = 1; j <= 5; j++) {
+                Category subCategory = Category.of(0L, "Category " + i + " - Subcategory " + j, 2, parentCategory, new ArrayList<>());
+                categories.add(subCategory);
+            }
+        }
+        
+        categoryRepository.saveAll(categories);
+    }
+    
+    @Test
+    @DisplayName(value = "카테고리 전체 조회")
+    void testFindAllCategories() {
+        List<Category> categories = categoryRepository.findAllWithChildren();
+        
+        assertThat(categories.stream().filter(c -> c.getName().equals("Root")).toList().size())
+                .isOne();
+        
+        
+        List<Category> parentCategories = categories.stream()
+                .filter(c -> c.getLevel() == 1)
+                .toList();
+        
+        assertThat(parentCategories.size()).isEqualTo(5);
+        
+        
+        for (Category parent : parentCategories) {
+            assertThat(parent.getChildren().size()).isEqualTo(5);
+            for (int i = 1; i <= 5; i++) {
+                String expectedSubcategoryName = parent.getName() + " - Subcategory " + i;
+                assertThat(parent.getChildren().get(i-1).getName()).isEqualTo(expectedSubcategoryName);
+                assertThat(parent.getChildren().get(i-1).getLevel()).isEqualTo(2);
+            }
+        }
+        
+        // 출력은 실제 데이터를 보기 위해 사용됩니다 (옵션)
+        categories.forEach(System.out::println);
+    }
+}

--- a/src/test/java/org/kakaoshare/backend/domain/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/category/repository/CategoryRepositoryTest.java
@@ -26,19 +26,25 @@ class CategoryRepositoryTest {
     void setUp() {
         List<Category> categories = new ArrayList<>();
         
-        Category rootCategory = Category.of(ROOT_NAME, null, new ArrayList<>());
+        Category rootCategory = Category.builder()
+                .name(ROOT_NAME)
+                .parent(null)
+                .children(new ArrayList<>())
+                .build();
         
         for (int i = 1; i <= 5; i++) {
-            Category parentCategory = Category.of(
-                    "Category " + i,
-                    rootCategory,
-                    new ArrayList<>());
+            Category parentCategory = Category.builder()
+                    .name("Category " + i)
+                    .parent(rootCategory)
+                    .children(new ArrayList<>())
+                    .build();
             
             for (int j = 1; j <= 5; j++) {
-                Category subCategory = Category.of(
-                        "Category " + i + " - Subcategory " + j,
-                        parentCategory
-                        , new ArrayList<>());
+                Category subCategory = Category.builder()
+                        .name("Category " + i + " - Subcategory " + j)
+                        .parent(parentCategory)
+                        .children(new ArrayList<>())
+                        .build();
                 parentCategory.getChildren().add(subCategory);
                 categories.add(subCategory);
             }

--- a/src/test/java/org/kakaoshare/backend/domain/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/category/repository/CategoryRepositoryTest.java
@@ -23,15 +23,15 @@ class CategoryRepositoryTest {
     void setUp() {
         List<Category> categories = new ArrayList<>();
         
-        Category rootCategory = Category.of(0L, "Root", 0, null, new ArrayList<>());
+        Category rootCategory = Category.of(0L, "Root", null, new ArrayList<>());
         categories.add(rootCategory);
         
         for (int i = 1; i <= 5; i++) {
-            Category parentCategory = Category.of(0L, "Category " + i, 1, rootCategory, new ArrayList<>());
+            Category parentCategory = Category.of(0L, "Category " + i, rootCategory, new ArrayList<>());
             categories.add(parentCategory);
             
             for (int j = 1; j <= 5; j++) {
-                Category subCategory = Category.of(0L, "Category " + i + " - Subcategory " + j, 2, parentCategory, new ArrayList<>());
+                Category subCategory = Category.of(0L, "Category " + i + " - Subcategory " + j, parentCategory, new ArrayList<>());
                 categories.add(subCategory);
             }
         }
@@ -49,7 +49,8 @@ class CategoryRepositoryTest {
         
         
         List<Category> parentCategories = categories.stream()
-                .filter(c -> c.getLevel() == 1)
+                .filter(c->!c.getName().equals("Root"))
+                .filter(c -> c.getParent().getName().equals("Root"))
                 .toList();
         
         assertThat(parentCategories.size()).isEqualTo(5);
@@ -57,14 +58,10 @@ class CategoryRepositoryTest {
         
         for (Category parent : parentCategories) {
             assertThat(parent.getChildren().size()).isEqualTo(5);
-            for (int i = 1; i <= 5; i++) {
-                String expectedSubcategoryName = parent.getName() + " - Subcategory " + i;
-                assertThat(parent.getChildren().get(i-1).getName()).isEqualTo(expectedSubcategoryName);
-                assertThat(parent.getChildren().get(i-1).getLevel()).isEqualTo(2);
+            for (Category child : parent.getChildren()) {
+                assertThat(child.getName()).contains("Subcategory");
+                assertThat(child.getChildren()).isEmpty();
             }
         }
-        
-        // 출력은 실제 데이터를 보기 위해 사용됩니다 (옵션)
-        categories.forEach(System.out::println);
     }
 }

--- a/src/test/java/org/kakaoshare/backend/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/category/service/CategoryServiceTest.java
@@ -1,0 +1,68 @@
+package org.kakaoshare.backend.domain.category.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kakaoshare.backend.domain.category.dto.CategoryDto;
+import org.kakaoshare.backend.domain.category.entity.Category;
+import org.kakaoshare.backend.domain.category.repository.CategoryRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+    @InjectMocks
+    private CategoryService categoryService;
+    
+    @Mock
+    private CategoryRepository categoryRepository;
+    
+    @Test
+    @DisplayName(value = "카테고리 계층적 구조화 테스트")
+    void testCreateCategoryHierarchy() {
+        // given
+        List<Category> categories = createCategories();
+        given(categoryRepository.findAllWithChildren())
+                .willReturn(categories);
+        
+        // when
+        Category root = categories.stream()
+                .filter(category -> category.getName().equals("Root"))
+                .findFirst().orElseThrow();
+        
+        CategoryDto rootDto = categoryService.createCategoryRoot();
+        
+        // then
+        assertThat(rootDto.getCategoryId()).isEqualTo(CategoryDto.of(root).getCategoryId());
+        assertThat(rootDto.getLevel()).isEqualTo(0);
+        assertThat(rootDto.getCategoryName()).isEqualTo("Root");
+    }
+    
+    List<Category> createCategories() {
+        List<Category> categories = new ArrayList<>();
+        Category rootCategory = Category.of(0L, "Root", 0, null, new ArrayList<>());
+        
+        for (int i = 1; i <= 5; i++) {
+            Category parentCategory = Category.of(0L, "Category " + i, 1, rootCategory, new ArrayList<>());
+            categories.add(parentCategory);
+            
+            for (int j = 1; j <= 5; j++) {
+                Category subCategory = Category.of(0L, "Category " + i + " - Subcategory " + j, 2, parentCategory, new ArrayList<>());
+                parentCategory.getChildren().add(subCategory);
+                categories.add(subCategory);
+            }
+            rootCategory.getChildren().add(parentCategory);
+            categories.add(parentCategory);
+        }
+        categories.add(rootCategory);
+        return categories;
+    }
+}

--- a/src/test/java/org/kakaoshare/backend/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/category/service/CategoryServiceTest.java
@@ -53,9 +53,17 @@ class CategoryServiceTest {
     private List<Category> createTestCategories() {
         List<Category> categories = new ArrayList<>();
         for (int i = 1; i <= 5; i++) {
-            Category parentCategory = Category.of("Category " + i, null, new ArrayList<>());
+            Category parentCategory = Category.builder()
+                    .name("Category " + i)
+                    .parent(null)
+                    .children(new ArrayList<>())
+                    .build();
             for (int j = 1; j <= 5; j++) {
-                Category subCategory = Category.of("Category " + i + " - Subcategory " + j, parentCategory, null);
+                Category subCategory = Category.builder()
+                        .name("Category " + i + " - Subcategory " + j)
+                        .parent(parentCategory)
+                        .children(new ArrayList<>())
+                        .build();
                 parentCategory.getChildren().add(subCategory);
                 categories.add(subCategory);
             }

--- a/src/test/java/org/kakaoshare/backend/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/category/service/CategoryServiceTest.java
@@ -48,14 +48,14 @@ class CategoryServiceTest {
     
     List<Category> createCategories() {
         List<Category> categories = new ArrayList<>();
-        Category rootCategory = Category.of(0L, "Root", 0, null, new ArrayList<>());
+        Category rootCategory = Category.of(0L, "Root", null, new ArrayList<>());
         
         for (int i = 1; i <= 5; i++) {
-            Category parentCategory = Category.of(0L, "Category " + i, 1, rootCategory, new ArrayList<>());
+            Category parentCategory = Category.of(0L, "Category " + i, rootCategory, new ArrayList<>());
             categories.add(parentCategory);
             
             for (int j = 1; j <= 5; j++) {
-                Category subCategory = Category.of(0L, "Category " + i + " - Subcategory " + j, 2, parentCategory, new ArrayList<>());
+                Category subCategory = Category.of(0L, "Category " + i + " - Subcategory " + j, parentCategory, new ArrayList<>());
                 parentCategory.getChildren().add(subCategory);
                 categories.add(subCategory);
             }


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #12 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

카테고리 목록을 반환하는 로직을 작성했습니다.
- ~~추후에 client단에서 카테고리의 ID를 통해 request를 보낼 수 있지만, id값 만으로는 화면 구성에 어려움이 있어 보여 level을 응답에 담을 수 있도록 로직을 구현했습니다.~~
- 루트 카테고리를 도입해 상위 카테고리의 부모를 지정했습니다.

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

- <img width="320" alt="image" src="https://github.com/KakaoFunding/back-end/assets/88381563/15ae6dfc-450b-4c71-bdaf-7cc3ada6c2bf">


## 🙏리뷰 요구사항(선택)
- QuryDsl 첫 사용이라 일부 미숙할 수 있으니, 확인 부탁드립니다.
- 아직 구체적인 예외상황이 예측되지 않아 테스트케이스가 촘촘하지 않습니다. 테스트 구체화가 필요해보이는 부분에 리뷰 부탁드립니다.
