### PR TITLE
상품상세 조회 쿼리수정

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/option/dto/OptionDetailResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/option/dto/OptionDetailResponse.java
@@ -1,0 +1,9 @@
+package org.kakaoshare.backend.domain.option.dto;
+
+import lombok.Getter;
+
+@Getter
+public record OptionDetailResponse(Long id, String photo, String name) {
+    public OptionDetailResponse {
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/option/dto/OptionDetailResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/option/dto/OptionDetailResponse.java
@@ -1,8 +1,6 @@
 package org.kakaoshare.backend.domain.option.dto;
 
-import lombok.Getter;
 
-@Getter
 public record OptionDetailResponse(Long id, String photo, String name) {
     public OptionDetailResponse {
     }

--- a/src/main/java/org/kakaoshare/backend/domain/option/dto/OptionResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/option/dto/OptionResponse.java
@@ -1,13 +1,19 @@
 package org.kakaoshare.backend.domain.option.dto;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 public class OptionResponse {
-    private String name;
-    private String optionDetailName;
-    private Long additionalPrice;
-    private String photo;
+    private final Long optionsId;
+    private final String name;
+    private List<OptionDetailResponse> optionDetails;
+
+    public void setOptionDetails(List<OptionDetailResponse> optionDetails) {
+        this.optionDetails = optionDetails;
+    }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/option/dto/OptionResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/option/dto/OptionResponse.java
@@ -1,0 +1,13 @@
+package org.kakaoshare.backend.domain.option.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OptionResponse {
+    private String name;
+    private String optionDetailName;
+    private Long additionalPrice;
+    private String photo;
+}

--- a/src/main/java/org/kakaoshare/backend/domain/product/dto/DescriptionResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/dto/DescriptionResponse.java
@@ -2,6 +2,7 @@ package org.kakaoshare.backend.domain.product.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.kakaoshare.backend.domain.option.dto.OptionResponse;
 import org.kakaoshare.backend.domain.option.entity.Option;
 import org.kakaoshare.backend.domain.product.entity.Product;
 import org.kakaoshare.backend.domain.product.entity.ProductDescriptionPhoto;
@@ -17,23 +18,25 @@ public class DescriptionResponse {
     private final Long price;
     private final String type;
     private final String description;
-    private final List<ProductDescriptionPhoto> descriptionPhotos;
+    private final List<String> descriptionPhotos;
     private final String productName;
-    private final List<Option> options;
-    private final List<ProductThumbnail> productThumbnails;
+    private final List<OptionResponse> options;
+    private final List<String> productThumbnails;
     private final String brandName;
 
-    public static DescriptionResponse from(final Product product) {
+    public static DescriptionResponse from(final Product product, List<String> descriptionPhotosUrls,
+                                           List<OptionResponse> optionsResponses, List<String> productThumbnailsUrls) {
         return DescriptionResponse.builder()
                 .productId(product.getProductId())
                 .name(product.getName())
                 .price(product.getPrice())
                 .type(product.getType())
                 .description(product.getProductDetail().getDescription())
-                .descriptionPhotos(null)//TODO 2024 03 21 16:33:40 : 추후 수정 필요
+                .descriptionPhotos(descriptionPhotosUrls)
                 .productName(product.getProductDetail().getProductName())
-                .options(null)//TODO 2024 03 21 16:33:50 : 추후 수정 필요
-                .brandName(product.getBrandName())
+                .options(optionsResponses)
+                .productThumbnails(productThumbnailsUrls)
+                .brandName(product.getBrand().getName())
                 .build();
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustomImpl.java
@@ -7,7 +7,10 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.common.error.GlobalErrorCode;
+import org.kakaoshare.backend.common.error.exception.BusinessException;
 import org.kakaoshare.backend.common.util.sort.SortUtil;
 import org.kakaoshare.backend.common.util.sort.SortableRepository;
 import org.kakaoshare.backend.domain.brand.dto.QSimpleBrandDto;
@@ -51,6 +54,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
     private static final int PRODUCT_SIZE_GROUP_BY_BRAND = 9;
 
     private final JPAQueryFactory queryFactory;
+    private final BusinessException businessException;
 
     @Override
     public Page<Product4DisplayDto> findAllByCategoryId(final Long categoryId,
@@ -158,14 +162,12 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
     @Override
     public DescriptionResponse findProductWithDetailsAndPhotos(Long productId) {
         // 제품 기본 정보 조회
-        Product product = queryFactory
-                .selectFrom(QProduct.product)
-                .where(QProduct.product.productId.eq(productId))
-                .fetchOne();
+        Product product = Optional.ofNullable(queryFactory
+                        .selectFrom(QProduct.product)
+                        .where(QProduct.product.productId.eq(productId))
+                        .fetchOne())
+                .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
 
-        if (product == null) {
-            return null;
-        }
 
         List<String> descriptionPhotosUrls = queryFactory
                 .select(QProductDescriptionPhoto.productDescriptionPhoto.photoUrl)

--- a/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package org.kakaoshare.backend.domain.product.repository.query;
 
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -11,12 +12,21 @@ import org.kakaoshare.backend.common.util.sort.SortUtil;
 import org.kakaoshare.backend.common.util.sort.SortableRepository;
 import org.kakaoshare.backend.domain.brand.dto.QSimpleBrandDto;
 import org.kakaoshare.backend.domain.brand.dto.SimpleBrandDto;
+import org.kakaoshare.backend.domain.option.dto.OptionDetailResponse;
+import org.kakaoshare.backend.domain.option.dto.OptionResponse;
+import org.kakaoshare.backend.domain.option.entity.OptionDetail;
+import org.kakaoshare.backend.domain.option.entity.QOption;
+import org.kakaoshare.backend.domain.option.entity.QOptionDetail;
 import org.kakaoshare.backend.domain.product.dto.DescriptionResponse;
 import org.kakaoshare.backend.domain.product.dto.DetailResponse;
 import org.kakaoshare.backend.domain.product.dto.Product4DisplayDto;
 import org.kakaoshare.backend.domain.product.dto.ProductDto;
 import org.kakaoshare.backend.domain.product.dto.QProduct4DisplayDto;
 import org.kakaoshare.backend.domain.product.dto.QProductDto;
+import org.kakaoshare.backend.domain.product.entity.Product;
+import org.kakaoshare.backend.domain.product.entity.QProduct;
+import org.kakaoshare.backend.domain.product.entity.QProductDescriptionPhoto;
+import org.kakaoshare.backend.domain.product.entity.QProductThumbnail;
 import org.kakaoshare.backend.domain.search.dto.QSimpleBrandProductDto;
 import org.kakaoshare.backend.domain.search.dto.SimpleBrandProductDto;
 import org.springframework.data.domain.Page;
@@ -31,14 +41,17 @@ import static com.querydsl.core.group.GroupBy.groupBy;
 import static org.kakaoshare.backend.common.util.RepositoryUtils.*;
 import static org.kakaoshare.backend.domain.brand.entity.QBrand.brand;
 import static org.kakaoshare.backend.domain.category.entity.QCategory.category;
+import static org.kakaoshare.backend.domain.option.entity.QOption.option;
+import static org.kakaoshare.backend.domain.option.entity.QOptionDetail.optionDetail;
 import static org.kakaoshare.backend.domain.product.entity.QProduct.product;
+import static org.kakaoshare.backend.domain.product.entity.QProductDescriptionPhoto.productDescriptionPhoto;
 
 @RequiredArgsConstructor
 public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, SortableRepository {
     private static final int PRODUCT_SIZE_GROUP_BY_BRAND = 9;
-    
+
     private final JPAQueryFactory queryFactory;
-    
+
     @Override
     public Page<Product4DisplayDto> findAllByCategoryId(final Long categoryId,
                                                         final Pageable pageable) {
@@ -53,7 +66,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
         JPAQuery<Long> countQuery = countProduct(categoryId);
         return toPage(pageable, fetch, countQuery);
     }
-    
+
     @Override
     public Page<ProductDto> findAllByBrandId(final Long brandId,
                                              final Pageable pageable) {
@@ -66,11 +79,11 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
-        
+
         JPAQuery<Long> countQuery = countBrand(brandId);
         return toPage(pageable, fetch, countQuery);
     }
-    
+
     @Override
     public Page<Product4DisplayDto> findBySearchConditions(final String keyword,
                                                            final Integer minPrice,
@@ -84,7 +97,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
                         containsExpression(product.price, minPrice, maxPrice)
 //                        containsExpression(category.name, categories)
                 );
-        
+
         // TODO: 3/19/24 카테고리 필터링은 추후 구현 예정
         final JPAQuery<Product4DisplayDto> contentQuery = queryFactory.select(getProduct4DisplayDto())
                 .from(product)
@@ -100,9 +113,10 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
                 .orderBy(createOrderSpecifiers(product, pageable));
         return toPage(pageable, contentQuery, countQuery);
     }
-    
+
     @Override
-    public Page<SimpleBrandProductDto> findBySearchConditionsGroupByBrand(final String keyword, final Pageable pageable) {
+    public Page<SimpleBrandProductDto> findBySearchConditionsGroupByBrand(final String keyword,
+                                                                          final Pageable pageable) {
         final JPAQuery<Long> countQuery = queryFactory.select(product.brand.brandId.countDistinct())
                 .from(product)
                 .where(containsExpression(product.name, keyword));
@@ -114,24 +128,25 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
                 .transform(groupBy(brand.brandId)
                         .list(new QSimpleBrandProductDto(getSimpleBrandDto(), GroupBy.list(getProduct4DisplayDto())))
                 );
-        
+
         // TODO: 3/21/24 일단은 메모리에서 페이징하는 것으로 구현
         final Map<SimpleBrandDto, List<Product4DisplayDto>> productsGroupByBrand = fetch.stream()
                 .skip(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .collect(Collectors.toMap(
                         SimpleBrandProductDto::brand,
-                        brandProducts -> brandProducts.products().subList(0, Math.min(brandProducts.products().size(), PRODUCT_SIZE_GROUP_BY_BRAND))
+                        brandProducts -> brandProducts.products()
+                                .subList(0, Math.min(brandProducts.products().size(), PRODUCT_SIZE_GROUP_BY_BRAND))
                 ));
-        
+
         final List<SimpleBrandProductDto> content = productsGroupByBrand.keySet()
                 .stream()
                 .map(brand -> new SimpleBrandProductDto(brand, productsGroupByBrand.get(brand)))
                 .toList();
-        
+
         return toPage(pageable, content, countQuery);
     }
-    
+
     @Override
     public OrderSpecifier<?>[] getOrderSpecifiers(final Pageable pageable) {
         return Stream.concat(
@@ -139,30 +154,62 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
                 Stream.of(product.name.asc()) // 기본 정렬 조건
         ).toArray(OrderSpecifier[]::new);
     }
-    
+
     @Override
     public DescriptionResponse findProductWithDetailsAndPhotos(Long productId) {
-        return null;
-//        return queryFactory
-//                .select(Projections.bean(DescriptionResponse.class,
-//                        product.name,
-//                        product.price,
-//                        product.type,
-//                        product.photo,
-//                        product.productDetail.description.as("description"),
-//                        product.productDescriptionPhotos.as("descriptionPhotos"),
-//                        product.productDetail.as("hasPhoto"),
-//                        product.productDetail.productName.as("productName"),
-//                        product.options,
-//                        product.brand))
-//                .from(product)
-//                .leftJoin(product.productDetail).fetchJoin()
-//                .leftJoin(product.productDescriptionPhotos).fetchJoin()
-//                .leftJoin(product.options).fetchJoin()
-//                .where(product.productId.eq(productId))
-//                .fetchOne();
+        // 제품 기본 정보 조회
+        Product product = queryFactory
+                .selectFrom(QProduct.product)
+                .where(QProduct.product.productId.eq(productId))
+                .fetchOne();
+
+        if (product == null) {
+            return null;
+        }
+
+        List<String> descriptionPhotosUrls = queryFactory
+                .select(QProductDescriptionPhoto.productDescriptionPhoto.photoUrl)
+                .from(QProductDescriptionPhoto.productDescriptionPhoto)
+                .where(QProductDescriptionPhoto.productDescriptionPhoto.product.productId.eq(productId))
+                .fetch();
+
+        List<OptionResponse> optionsResponses = queryFactory
+                .select(Projections.constructor(
+                        OptionResponse.class,
+                        QOption.option.optionsId,
+                        QOption.option.name
+                ))
+                .from(QOption.option)
+                .where(QOption.option.product.productId.eq(productId))
+                .fetch();
+
+        // 각 옵션에 대한 상세 정보 조회 및 설정
+        for (OptionResponse optionResponse : optionsResponses) {
+            List<OptionDetailResponse> detailsResponses = queryFactory
+                    .select(Projections.constructor(
+                            OptionDetailResponse.class,
+                            QOptionDetail.optionDetail.optionDetailId,
+                            QOptionDetail.optionDetail.name,
+                            QOptionDetail.optionDetail.additionalPrice,
+                            QOptionDetail.optionDetail.photo
+                    ))
+                    .from(QOptionDetail.optionDetail)
+                    .where(QOptionDetail.optionDetail.option.optionsId.eq(optionResponse.getOptionsId()))
+                    .fetch();
+
+            optionResponse.setOptionDetails(detailsResponses);
+        }
+        List<String> productThumbnailsUrls = queryFactory
+                .select(QProductThumbnail.productThumbnail.thumbnailUrl)
+                .from(QProductThumbnail.productThumbnail)
+                .where(QProductThumbnail.productThumbnail.product.productId.eq(productId))
+                .fetch();
+
+        return DescriptionResponse.from(product, descriptionPhotosUrls, optionsResponses, productThumbnailsUrls);
     }
-    
+
+
+
     @Override
     public DetailResponse findProductDetail(Long productId) {
         return null;
@@ -187,14 +234,14 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
 //                .where(product.productId.eq(productId))
 //                .fetchOne();
     }
-    
+
     private QSimpleBrandDto getSimpleBrandDto() {
         return new QSimpleBrandDto(
                 brand.brandId,
                 brand.name,
                 brand.iconPhoto);
     }
-    
+
     private QProduct4DisplayDto getProduct4DisplayDto() {
         return new QProduct4DisplayDto(
                 product.productId,
@@ -204,7 +251,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
                 product.brand.name.as("brandName"),
                 product.wishCount.longValue().as("wishCount"));
     }
-    
+
     private QProductDto getProductDto() {
         return new QProductDto(
                 product.productId,
@@ -212,19 +259,19 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
                 product.photo,
                 product.price);
     }
-    
+
     private BooleanExpression categoryIdEqualTo(final Long categoryId) {
         BooleanExpression isParentCategory = product.category
                 .in(JPAExpressions
                         .select(category)
                         .from(category)
                         .where(category.parent.categoryId.eq(categoryId)));
-        
+
         BooleanExpression isChildCategory = product.category.categoryId.eq(categoryId);
-        
+
         return isChildCategory.or(isParentCategory);
     }
-    
+
     private JPAQuery<Long> countBrand(final Long brandId) {
         return queryFactory
                 .select(product.countDistinct())
@@ -232,7 +279,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
                 .join(product.brand, brand)
                 .where(brand.brandId.eq(brandId));
     }
-    
+
     private JPAQuery<Long> countProduct(final Long categoryId) {
         return queryFactory
                 .select(product.countDistinct())

--- a/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustomImpl.java
@@ -55,7 +55,6 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
     private static final int PRODUCT_SIZE_GROUP_BY_BRAND = 9;
 
     private final JPAQueryFactory queryFactory;
-    private final BusinessException businessException;
 
     @Override
     public Page<Product4DisplayDto> findAllByCategoryId(final Long categoryId,


### PR DESCRIPTION
## #️⃣연관된 이슈

close #70 

## 📝작업 내용
상품 상세조회 쿼리 수정(OneToMany)관계 사라진 이후로 dto들을 통해 정적팩토리 메소드로 응답dto 생성


## ✅테스트 결과
<img width="315" alt="image" src="https://github.com/KakaoFunding/back-end/assets/93575221/cec06001-e2cf-4542-ab1e-a35c4e1e167e">


## 🙏리뷰 요구사항

상품 상세조회 로직이 좀 변경이 많이 되긴했습니다.. onrToMany가 없다보니 getter도 못써서 부자연스럽게 보이긴 하는데 어떻게 다듬으면 좋을지 리뷰해주시면 감사할것 같습니다
