### PR TITLE
결제 관련 오류, ReceiptOption 엔티티 수정

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/option/repository/OptionRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/option/repository/OptionRepository.java
@@ -1,8 +1,17 @@
 package org.kakaoshare.backend.domain.option.repository;
 
 import org.kakaoshare.backend.domain.option.entity.Option;
+import org.kakaoshare.backend.domain.option.repository.query.OptionRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 
-public interface OptionRepository extends JpaRepository<Option, Long> {
+public interface OptionRepository extends JpaRepository<Option, Long>, OptionRepositoryCustom {
+    @Query("SELECT od.option " +
+            "FROM OptionDetail od " +
+            "LEFT JOIN od.option " +
+            "WHERE od.optionDetailId IN :optionDetailIds")
+    List<Option> findByOptionDetailIds(final List<Long> optionDetailIds);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/option/repository/OptionRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/option/repository/OptionRepository.java
@@ -1,14 +1,13 @@
 package org.kakaoshare.backend.domain.option.repository;
 
 import org.kakaoshare.backend.domain.option.entity.Option;
-import org.kakaoshare.backend.domain.option.repository.query.OptionRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 
-public interface OptionRepository extends JpaRepository<Option, Long>, OptionRepositoryCustom {
+public interface OptionRepository extends JpaRepository<Option, Long> {
     @Query("SELECT od.option " +
             "FROM OptionDetail od " +
             "LEFT JOIN od.option " +

--- a/src/main/java/org/kakaoshare/backend/domain/payment/dto/OrderDetail.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/dto/OrderDetail.java
@@ -4,12 +4,12 @@ import java.util.List;
 
 /**
  * 결제 준비, 승인 과정에 모두 사용되는 DTO 클래스 입니다.
- * 결제 준비 응답값에 포함되며 추후 승인 과정 요청시 이 값을 프론트로부터 다시 전달받아 Order 객체를 만드는데 사용합니다.
+ * 결제 준비 응답값에 포함되며 추후 승인 과정 요청시 이 값을 Redis에서 꺼내와 Order, Payment, Gift 등 객체를 만드는데 사용합니다.
  * 추후, 할인 기능이 구현되면 이 클래스에 discountAmount 필드를 추가하면 됩니다.
  * @param productId 상품 PK
- * @param stockQuantity 수량
+ * @param quantity 수량
  * @param optionDetailIds 선택한 옵션 상세 PK
  * @author kim-minwoo
  */
-public record OrderDetail(String orderNumber, Long productId, Integer stockQuantity, List<Long> optionDetailIds) {
+public record OrderDetail(String orderNumber, Long productId, Integer quantity, List<Long> optionDetailIds) {
 }

--- a/src/main/java/org/kakaoshare/backend/domain/payment/dto/ready/request/PaymentReadyProductDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/dto/ready/request/PaymentReadyProductDto.java
@@ -1,0 +1,4 @@
+package org.kakaoshare.backend.domain.payment.dto.ready.request;
+
+public record PaymentReadyProductDto(String name, int quantity, int totalAmount) {
+}

--- a/src/main/java/org/kakaoshare/backend/domain/payment/dto/ready/request/PaymentReadyRequest.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/dto/ready/request/PaymentReadyRequest.java
@@ -5,10 +5,10 @@ import org.kakaoshare.backend.domain.payment.dto.OrderDetail;
 import java.util.List;
 
 public record PaymentReadyRequest(
-        Long productId, String name, Integer totalAmount, Integer discountAmount,
-        Integer stockQuantity, List<Long> optionDetailIds) {
+        Long productId, Integer totalAmount, Integer discountAmount,
+        Integer quantity, List<Long> optionDetailIds) {
 
     public OrderDetail toOrderDetail(final String orderNumber) {
-        return new OrderDetail(orderNumber, productId, stockQuantity, optionDetailIds);
+        return new OrderDetail(orderNumber, productId, quantity, optionDetailIds);
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/exception/PaymentErrorCode.java
@@ -1,7 +1,8 @@
 package org.kakaoshare.backend.domain.payment.exception;
 
 public enum PaymentErrorCode {
-    INVALID_AMOUNT("결제 금액이 올바르지 않습니다.");
+    INVALID_AMOUNT("결제 금액이 올바르지 않습니다."),
+    INVALID_OPTION("선택한 옵션이 올바르지 않습니다.");
 
     private final String message;
 

--- a/src/main/java/org/kakaoshare/backend/domain/payment/service/KakaoPayRequestProvider.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/service/KakaoPayRequestProvider.java
@@ -1,8 +1,8 @@
 package org.kakaoshare.backend.domain.payment.service;
 
-import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyRequest;
 import org.kakaoshare.backend.domain.payment.dto.approve.request.KakaoPayApproveRequest;
 import org.kakaoshare.backend.domain.payment.dto.ready.request.KakaoPayReadyRequest;
+import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyProductDto;
 import org.kakaoshare.backend.domain.payment.dto.success.request.PaymentSuccessRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -32,11 +32,11 @@ public class KakaoPayRequestProvider {
     }
 
     public KakaoPayReadyRequest createReadyRequest(final String providerId,
-                                                   final List<PaymentReadyRequest> paymentRequests,
+                                                   final List<PaymentReadyProductDto> paymentProductReadyRequests,
                                                    final String orderNumber) {
-        final int totalAmount = getTotalAmount(paymentRequests);
-        final int quantity = getQuantity(paymentRequests);
-        final String productName = getProductName(paymentRequests);
+        final int totalAmount = getTotalAmount(paymentProductReadyRequests);
+        final int quantity = getQuantity(paymentProductReadyRequests);
+        final String productName = getProductName(paymentProductReadyRequests);
         return new KakaoPayReadyRequest(cid, cidSecret, orderNumber, providerId, productName, quantity, totalAmount, 0, approvalUrl, cancelUrl, failUrl);
     }
 
@@ -48,24 +48,24 @@ public class KakaoPayRequestProvider {
         return new KakaoPayApproveRequest(cid, cidSecret, tid, orderNumber, providerId, pgToken);
     }
 
-    private int getTotalAmount(final List<PaymentReadyRequest> paymentRequests) {
-        return paymentRequests.stream()
-                .mapToInt(PaymentReadyRequest::totalAmount)
+    private int getTotalAmount(final List<PaymentReadyProductDto> paymentProductReadyRequests) {
+        return paymentProductReadyRequests.stream()
+                .mapToInt(PaymentReadyProductDto::totalAmount)
                 .sum();
     }
 
-    private int getQuantity(final List<PaymentReadyRequest> paymentRequests) {
-        return paymentRequests.stream()
-                .mapToInt(PaymentReadyRequest::stockQuantity)
+    private int getQuantity(final List<PaymentReadyProductDto> paymentProductReadyRequests) {
+        return paymentProductReadyRequests.stream()
+                .mapToInt(PaymentReadyProductDto::quantity)
                 .sum();
     }
 
-    private String getProductName(final List<PaymentReadyRequest> paymentRequests) {
-        final String firstProductName = paymentRequests.get(0).name();
+    private String getProductName(final List<PaymentReadyProductDto> paymentProductReadyRequests) {
+        final String firstProductName = paymentProductReadyRequests.get(0).name();
         final StringBuilder stringBuilder = new StringBuilder(firstProductName);
-        if (paymentRequests.size() > 1) {
+        if (paymentProductReadyRequests.size() > 1) {
             stringBuilder.append(PRODUCT_NAME_SEPARATOR);
-            stringBuilder.append(paymentRequests.size() - 1);
+            stringBuilder.append(paymentProductReadyRequests.size() - 1);
             stringBuilder.append(PRODUCT_NAME_SUFFIX);
         }
 

--- a/src/main/java/org/kakaoshare/backend/domain/payment/service/KakaoPayRequestProvider.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/service/KakaoPayRequestProvider.java
@@ -32,11 +32,11 @@ public class KakaoPayRequestProvider {
     }
 
     public KakaoPayReadyRequest createReadyRequest(final String providerId,
-                                                   final List<PaymentReadyProductDto> paymentProductReadyRequests,
+                                                   final List<PaymentReadyProductDto> paymentReadyProductDtos,
                                                    final String orderNumber) {
-        final int totalAmount = getTotalAmount(paymentProductReadyRequests);
-        final int quantity = getQuantity(paymentProductReadyRequests);
-        final String productName = getProductName(paymentProductReadyRequests);
+        final int totalAmount = getTotalAmount(paymentReadyProductDtos);
+        final int quantity = getQuantity(paymentReadyProductDtos);
+        final String productName = getProductName(paymentReadyProductDtos);
         return new KakaoPayReadyRequest(cid, cidSecret, orderNumber, providerId, productName, quantity, totalAmount, 0, approvalUrl, cancelUrl, failUrl);
     }
 
@@ -48,24 +48,24 @@ public class KakaoPayRequestProvider {
         return new KakaoPayApproveRequest(cid, cidSecret, tid, orderNumber, providerId, pgToken);
     }
 
-    private int getTotalAmount(final List<PaymentReadyProductDto> paymentProductReadyRequests) {
-        return paymentProductReadyRequests.stream()
+    private int getTotalAmount(final List<PaymentReadyProductDto> paymentReadyProductDtos) {
+        return paymentReadyProductDtos.stream()
                 .mapToInt(PaymentReadyProductDto::totalAmount)
                 .sum();
     }
 
-    private int getQuantity(final List<PaymentReadyProductDto> paymentProductReadyRequests) {
-        return paymentProductReadyRequests.stream()
+    private int getQuantity(final List<PaymentReadyProductDto> paymentReadyProductDtos) {
+        return paymentReadyProductDtos.stream()
                 .mapToInt(PaymentReadyProductDto::quantity)
                 .sum();
     }
 
-    private String getProductName(final List<PaymentReadyProductDto> paymentProductReadyRequests) {
-        final String firstProductName = paymentProductReadyRequests.get(0).name();
+    private String getProductName(final List<PaymentReadyProductDto> paymentReadyProductDtos) {
+        final String firstProductName = paymentReadyProductDtos.get(0).name();
         final StringBuilder stringBuilder = new StringBuilder(firstProductName);
-        if (paymentProductReadyRequests.size() > 1) {
+        if (paymentReadyProductDtos.size() > 1) {
             stringBuilder.append(PRODUCT_NAME_SEPARATOR);
-            stringBuilder.append(paymentProductReadyRequests.size() - 1);
+            stringBuilder.append(paymentReadyProductDtos.size() - 1);
             stringBuilder.append(PRODUCT_NAME_SUFFIX);
         }
 

--- a/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentService.java
@@ -151,7 +151,7 @@ public class PaymentService {
                 .map(orderDetail -> new Receipt(
                         orderDetail.orderNumber(),
                         productRepository.getReferenceById(orderDetail.productId()),
-                        orderDetail.stockQuantity(),
+                        orderDetail.quantity(),
                         recipient,
                         receiver,
                         getReceiptOptions(orderDetail.optionDetailIds())))
@@ -189,7 +189,7 @@ public class PaymentService {
 
     private OrderSummaryResponse getOrderSummary(final OrderDetail orderDetail) {
         final ProductSummaryResponse productSummaryResponse = productRepository.findAllProductSummaryById(orderDetail.productId());
-        return new OrderSummaryResponse(productSummaryResponse, orderDetail.stockQuantity(), getOptionSummaryResponses(orderDetail.optionDetailIds()));
+        return new OrderSummaryResponse(productSummaryResponse, orderDetail.quantity(), getOptionSummaryResponses(orderDetail.optionDetailIds()));
     }
 
     private List<OptionSummaryResponse> getOptionSummaryResponses(final List<Long> optionDetailIds) {

--- a/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentService.java
@@ -5,6 +5,7 @@ import org.kakaoshare.backend.common.util.RedisUtils;
 import org.kakaoshare.backend.domain.gift.entity.Gift;
 import org.kakaoshare.backend.domain.gift.repository.GiftRepository;
 import org.kakaoshare.backend.domain.member.entity.Member;
+import org.kakaoshare.backend.domain.member.exception.MemberException;
 import org.kakaoshare.backend.domain.member.repository.MemberRepository;
 import org.kakaoshare.backend.domain.option.dto.OptionSummaryResponse;
 import org.kakaoshare.backend.domain.option.entity.Option;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.kakaoshare.backend.domain.member.exception.MemberErrorCode.NOT_FOUND;
 import static org.kakaoshare.backend.domain.payment.exception.PaymentErrorCode.INVALID_AMOUNT;
 import static org.kakaoshare.backend.domain.payment.exception.PaymentErrorCode.INVALID_OPTION;
 
@@ -207,6 +209,6 @@ public class PaymentService {
 
     private Member findMemberByProviderId(final String providerId) {
         return memberRepository.findByProviderId(providerId)
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(() -> new MemberException(NOT_FOUND));
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentWebClientService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentWebClientService.java
@@ -36,9 +36,9 @@ public class PaymentWebClientService {
     }
 
     public KakaoPayReadyResponse ready(final String providerId,
-                                       final List<PaymentReadyProductDto> paymentProductReadyRequests,
+                                       final List<PaymentReadyProductDto> paymentReadyProductDtos,
                                        final String orderNumber) {
-        final KakaoPayReadyRequest kakaoPayReadyRequest = requestProvider.createReadyRequest(providerId, paymentProductReadyRequests, orderNumber);
+        final KakaoPayReadyRequest kakaoPayReadyRequest = requestProvider.createReadyRequest(providerId, paymentReadyProductDtos, orderNumber);
         return webClient.post()
                 .uri(readyUrl)
                 .header(HttpHeaders.AUTHORIZATION, SECRET_KEY_PREFIX + secretKey)

--- a/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentWebClientService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentWebClientService.java
@@ -1,9 +1,9 @@
 package org.kakaoshare.backend.domain.payment.service;
 
-import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyRequest;
 import org.kakaoshare.backend.domain.payment.dto.approve.request.KakaoPayApproveRequest;
 import org.kakaoshare.backend.domain.payment.dto.approve.response.KakaoPayApproveResponse;
 import org.kakaoshare.backend.domain.payment.dto.ready.request.KakaoPayReadyRequest;
+import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyProductDto;
 import org.kakaoshare.backend.domain.payment.dto.ready.response.KakaoPayReadyResponse;
 import org.kakaoshare.backend.domain.payment.dto.success.request.PaymentSuccessRequest;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,9 +36,9 @@ public class PaymentWebClientService {
     }
 
     public KakaoPayReadyResponse ready(final String providerId,
-                                       final List<PaymentReadyRequest> paymentReadyRequests,
+                                       final List<PaymentReadyProductDto> paymentProductReadyRequests,
                                        final String orderNumber) {
-        final KakaoPayReadyRequest kakaoPayReadyRequest = requestProvider.createReadyRequest(providerId, paymentReadyRequests, orderNumber);
+        final KakaoPayReadyRequest kakaoPayReadyRequest = requestProvider.createReadyRequest(providerId, paymentProductReadyRequests, orderNumber);
         return webClient.post()
                 .uri(readyUrl)
                 .header(HttpHeaders.AUTHORIZATION, SECRET_KEY_PREFIX + secretKey)

--- a/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustom.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustom.java
@@ -18,5 +18,6 @@ public interface ProductRepositoryCustom {
     DetailResponse findProductDetail(Long productId);
     Page<Product4DisplayDto> findBySearchConditions(final String keyword, final Integer minPrice, final Integer maxPrice, final List<String> categories, final Pageable pageable);
     Page<SimpleBrandProductDto> findBySearchConditionsGroupByBrand(final String keyword, final Pageable pageable);
-    Map<Long, Long> findAllPriceByIdsGroupById(List<Long> productIds);
+    Map<Long, Long> findAllPriceByIdsGroupById(final List<Long> productIds);
+    Map<Long, String> findAllNameByIdsGroupById(final List<Long> productIds);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustomImpl.java
@@ -143,6 +143,16 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
     }
 
     @Override
+    public Map<Long, String> findAllNameByIdsGroupById(final List<Long> productIds) {
+        return queryFactory.selectFrom(product)
+                .where(containsExpression(product.productId, productIds))
+                .transform(
+                        groupBy(product.productId)
+                                .as(product.name)
+                );
+    }
+
+    @Override
     public OrderSpecifier<?>[] getOrderSpecifiers(final Pageable pageable) {
         return Stream.concat(
                 Stream.of(SortUtil.from(pageable)),

--- a/src/main/java/org/kakaoshare/backend/domain/receipt/entity/ReceiptOption.java
+++ b/src/main/java/org/kakaoshare/backend/domain/receipt/entity/ReceiptOption.java
@@ -12,11 +12,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.kakaoshare.backend.domain.base.entity.BaseTimeEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ReceiptOption {
+public class ReceiptOption extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long receipt_option_id;

--- a/src/test/java/org/kakaoshare/backend/fixture/MemberFixture.java
+++ b/src/test/java/org/kakaoshare/backend/fixture/MemberFixture.java
@@ -6,7 +6,8 @@ import org.kakaoshare.backend.domain.member.entity.Member;
 import static org.kakaoshare.backend.domain.member.entity.Gender.MALE;
 
 public enum MemberFixture {
-    KAKAO("카카오", MALE, "01012341234", "123");
+    KAKAO("카카오", MALE, "01012341234", "123"),
+    KIM("김민우", MALE, "01011111111", "456");
 
     private final String name;
     private final Gender gender;


### PR DESCRIPTION
## #️⃣연관된 이슈

close #81

## 📝작업 내용
- 결제 준비시 선택한 옵션 검증 추가
- 결제 준비시 결제 금액 검증 버그 수정
- 결제 준비시 프론트로부터 상품명을 전달 안 받도록 수정
- 결제 관련 DTO의 "수량"을 나타내는 필드명을 `stockQuantity` 에서 `quantity`로 수정
- 기타 오류 상황(e.g. 회원 인증X)마다 알맞는 예외를 발생시키도록 수정
- `ReceiptOption` 이 `BaseTimeEntity`를 상속받도록 수정

## ✅테스트 결과
### Service
<img width="451" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/27a72227-b49a-44d5-b34b-271163c525e0">

### Controller
포스트맨 참고

## 🙏리뷰 요구사항(선택)
결제 로직이 매우 복잡합니다! 이해안되는 부분있으시면 바로 물어봐주세요!