### PR TITLE
Feature/fix wish reservation

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/wish/controller/WishController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/wish/controller/WishController.java
@@ -6,6 +6,8 @@ import org.kakaoshare.backend.domain.wish.service.WishService;
 import org.kakaoshare.backend.jwt.util.LoggedInMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,9 +20,15 @@ public class WishController {
     private final WishService wishService;
     
     @GetMapping("/me")
-    public ResponseEntity<?> getWishList(@LoggedInMember String providerId){
+    public ResponseEntity<?> getWishList(@LoggedInMember String providerId) {
         List<WishDetail> wishList = wishService.getMembersWishList(providerId);
         return ResponseEntity.ok(wishList);
     }
     
+    @PostMapping("/{wishId}/change-type")
+    public ResponseEntity<?> changeWishType(@LoggedInMember String providerId,
+                                            @PathVariable(name = "wishId") Long wishId) {
+        wishService.changeWishType(providerId,wishId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/wish/dto/WishDetail.java
+++ b/src/main/java/org/kakaoshare/backend/domain/wish/dto/WishDetail.java
@@ -1,3 +1,3 @@
 package org.kakaoshare.backend.domain.wish.dto;
-public record WishDetail(Long productId, String productName, Long productPrice, String productPhoto, boolean isPublic) {
+public record WishDetail(Long wishId,Long productId, String productName, Long productPrice, String productPhoto, boolean isPublic) {
 }

--- a/src/main/java/org/kakaoshare/backend/domain/wish/entity/Wish.java
+++ b/src/main/java/org/kakaoshare/backend/domain/wish/entity/Wish.java
@@ -53,4 +53,7 @@ public class Wish extends BaseTimeEntity {
     public boolean equalProductId(final Long productId) {
         return this.product.getProductId() == productId;
     }
+    public void changeScopeOfDisclosure(){
+        this.isPublic=!this.isPublic;
+    }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/wish/repository/query/WishRepositoryCustom.java
+++ b/src/main/java/org/kakaoshare/backend/domain/wish/repository/query/WishRepositoryCustom.java
@@ -1,9 +1,12 @@
 package org.kakaoshare.backend.domain.wish.repository.query;
 
+import org.kakaoshare.backend.domain.member.entity.Member;
 import org.kakaoshare.backend.domain.wish.dto.WishDetail;
+import org.kakaoshare.backend.domain.wish.entity.Wish;
 
 import java.util.List;
 
 public interface WishRepositoryCustom {
     List<WishDetail> findWishDetailsByProviderId(final String providerId);
+    boolean isContainInWishList(Wish wish, Member member, Long productId);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/wish/repository/query/WishRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/wish/repository/query/WishRepositoryCustomImpl.java
@@ -9,7 +9,6 @@ import org.kakaoshare.backend.domain.wish.dto.WishDetail;
 import org.kakaoshare.backend.domain.wish.entity.QWish;
 import org.kakaoshare.backend.domain.wish.entity.Wish;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.Assert;
 
 import java.util.List;
 
@@ -51,7 +50,7 @@ public class WishRepositoryCustomImpl implements WishRepositoryCustom {
                 .from(QWish.wish)
                 .where(existsCondition)
                 .fetchOne();
-        Assert.notNull(count,"count query must not to be null!");
-        return count >0;
+
+        return count != null && count > 0;
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/wish/repository/query/WishRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/wish/repository/query/WishRepositoryCustomImpl.java
@@ -1,10 +1,15 @@
 package org.kakaoshare.backend.domain.wish.repository.query;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.domain.member.entity.Member;
 import org.kakaoshare.backend.domain.wish.dto.WishDetail;
+import org.kakaoshare.backend.domain.wish.entity.QWish;
+import org.kakaoshare.backend.domain.wish.entity.Wish;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.Assert;
 
 import java.util.List;
 
@@ -33,5 +38,19 @@ public class WishRepositoryCustomImpl implements WishRepositoryCustom {
                 .on(wish.member.providerId.eq(providerId))
                 .join(wish.product, product)
                 .fetch();
+    }
+    
+    @Override
+    public boolean isContainInWishList(Wish wish, Member member, Long productId) {
+        BooleanExpression existsCondition = QWish.wish.member.eq(member)
+                .and(QWish.wish.product.productId.eq(productId));
+        
+        Long count = queryFactory
+                .select(QWish.wish.count())
+                .from(QWish.wish)
+                .where(existsCondition)
+                .fetchOne();
+        Assert.notNull(count,"count query must not to be null!");
+        return count >0;
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/wish/repository/query/WishRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/wish/repository/query/WishRepositoryCustomImpl.java
@@ -28,6 +28,7 @@ public class WishRepositoryCustomImpl implements WishRepositoryCustom {
                 .select(
                         Projections.constructor(
                                 WishDetail.class,
+                                wish.wishId,
                                 product.productId,
                                 product.name,
                                 product.price,

--- a/src/main/java/org/kakaoshare/backend/domain/wish/service/WishService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/wish/service/WishService.java
@@ -49,7 +49,7 @@ public class WishService {
         Wish wish = createWish(event, member);
         wish.checkIsPublic(event.getType());
         
-        if(wishRepository.isContainInWishList(wish,member,event.getProduct().getProductId())){
+        if (wishRepository.isContainInWishList(wish, member, event.getProduct().getProductId())) {
             throw new WishException(WishErrorCode.SAVING_FAILED);
         }
         try {
@@ -109,4 +109,13 @@ public class WishService {
                 .build();
     }
     
+    public void changeWishType(final String providerId, final Long wishId) {
+        boolean exists = getMembersWishList(providerId).stream()
+                .anyMatch(wishDetail -> wishDetail.wishId().equals(wishId));
+        if (!exists) {
+            throw new WishException(WishErrorCode.NOT_FOUND);
+        }
+        Wish wish = wishRepository.findById(wishId).orElseThrow(() -> new WishException(WishErrorCode.NOT_FOUND));
+        wish.changeScopeOfDisclosure();
+    }
 }

--- a/src/test/java/org/kakaoshare/backend/domain/wish/repository/WishRepositoryTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/wish/repository/WishRepositoryTest.java
@@ -1,30 +1,63 @@
-//package org.kakaoshare.backend.domain.wish.repository;
-//
-//import org.junit.jupiter.api.Test;
-//import org.kakaoshare.backend.common.RepositoryTest;
-//import org.kakaoshare.backend.domain.member.entity.Member;
-//import org.kakaoshare.backend.domain.member.repository.MemberRepository;
-//import org.kakaoshare.backend.domain.product.entity.Product;
-//import org.kakaoshare.backend.domain.product.repository.ProductRepository;
-//import org.kakaoshare.backend.domain.wish.dto.WishDetail;
-//import org.kakaoshare.backend.domain.wish.entity.Wish;
-//import org.kakaoshare.backend.fixture.MemberFixture;
-//import org.springframework.beans.factory.annotation.Autowired;
-//
-//import java.util.List;
-//
-//@RepositoryTest
-//class WishRepositoryTest {
-//    @Autowired
-//    private WishRepository wishRepository;
-//
-//    @Autowired
-//    private MemberRepository memberRepository;
-//
-//    @Autowired
-//    private ProductRepository productRepository;
-//
-//
+package org.kakaoshare.backend.domain.wish.repository;
+
+import org.junit.jupiter.api.Test;
+import org.kakaoshare.backend.common.RepositoryTest;
+import org.kakaoshare.backend.domain.member.entity.Member;
+import org.kakaoshare.backend.domain.member.repository.MemberRepository;
+import org.kakaoshare.backend.domain.product.entity.Product;
+import org.kakaoshare.backend.domain.product.repository.ProductRepository;
+import org.kakaoshare.backend.domain.wish.entity.Wish;
+import org.kakaoshare.backend.fixture.WishFixture;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+class WishRepositoryTest {
+    @Autowired
+    private WishRepository wishRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+    
+    @Test
+    void testSaveWishIfNotExists() {
+        // given
+        List<WishFixture> fixtures = Arrays.stream(WishFixture.values()).toList();
+        
+        List<Product> products = fixtures.stream()
+                .map(WishFixture::getProduct)
+                .toList();
+        
+        List<Member> members = fixtures.stream()
+                .map(WishFixture::getMember)
+                .toList();
+        productRepository.saveAllAndFlush(products.stream().distinct().toList());
+        memberRepository.saveAllAndFlush(members.stream().distinct().toList());
+        
+        List<Wish> wishes = fixtures.stream()
+                .map(WishFixture::생성)
+                .toList();
+        
+        for (int i = 0; i < wishes.size(); i++) {
+            Wish wish = wishes.get(i);
+            boolean containInWishList = wishRepository.isContainInWishList(wish, members.get(i), products.get(i).getProductId());
+            assertThat(containInWishList).isEqualTo(false);
+            wishRepository.saveAndFlush(wish);
+            containInWishList = wishRepository.isContainInWishList(wish, members.get(i), products.get(i).getProductId());
+            assertThat(containInWishList).isEqualTo(true);
+        }
+        // then
+        
+    }
+
+
 //    @Test
 //    void w() {
 //        // given
@@ -59,4 +92,4 @@
 //        // then
 //
 //    }
-//}
+}

--- a/src/test/java/org/kakaoshare/backend/domain/wish/repository/WishRepositoryTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/wish/repository/WishRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.kakaoshare.backend.domain.wish.repository;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kakaoshare.backend.common.RepositoryTest;
 import org.kakaoshare.backend.domain.member.entity.Member;
@@ -27,6 +28,7 @@ class WishRepositoryTest {
     private ProductRepository productRepository;
     
     @Test
+    @DisplayName("위시는 중복된 상품을 기준으로 제외하고 저장한다")
     void testSaveWishIfNotExists() {
         // given
         List<WishFixture> fixtures = Arrays.stream(WishFixture.values()).toList();
@@ -56,40 +58,4 @@ class WishRepositoryTest {
         // then
         
     }
-
-
-//    @Test
-//    void w() {
-//        // given
-//        Member member = MemberFixture.KAKAO.생성();
-//        Member savedMember = memberRepository.saveAndFlush(member);
-//        List<Product> products = productRepository.findAll()
-//                .stream()
-//                .limit(500)
-//                .toList();
-//
-//        List<Wish> wishes = products.stream()
-//                .map(product -> Wish.builder()
-//                        .member(savedMember)
-//                        .product(product)
-//                        .isPublic(true).build())
-//                .toList();
-//        wishRepository.saveAll(wishes);
-//
-//        // when
-////        List<WishDetail> wishDetails = wishRepository.findWishDetailsByProviderId(savedMember.getProviderId());
-//        List<WishDetail> wishDetails = wishRepository.findByMember_ProviderId(savedMember.getProviderId())
-//                .stream()
-//                .map(wish ->
-//                        new WishDetail(
-//                                wish.getProduct().getProductId(),
-//                                wish.getProduct().getName(),
-//                                wish.getProduct().getPrice(),
-//                                wish.getProduct().getPhoto(),
-//                                wish.getIsPublic()
-//                        ))
-//                .toList();
-//        // then
-//
-//    }
 }

--- a/src/test/java/org/kakaoshare/backend/fixture/WishFixture.java
+++ b/src/test/java/org/kakaoshare/backend/fixture/WishFixture.java
@@ -4,22 +4,24 @@ import org.kakaoshare.backend.domain.member.entity.Member;
 import org.kakaoshare.backend.domain.product.entity.Product;
 import org.kakaoshare.backend.domain.wish.entity.Wish;
 public enum WishFixture {
-    TEST_WISH1(ProductFixture.TEST_PRODUCT.브랜드_설정_생성(BrandFixture.EDIYA.생성()), MemberFixture.KAKAO.생성(), true),
-    TEST_WISH2(ProductFixture.CAKE.브랜드_설정_생성(BrandFixture.STARBUCKS.생성()), MemberFixture.KAKAO.생성(), false),
-    TEST_WISH3(ProductFixture.COFFEE.브랜드_설정_생성(BrandFixture.EDIYA.생성()), MemberFixture.KAKAO.생성(), false),
-    TEST_WISH4(ProductFixture.TEST_PRODUCT.브랜드_설정_생성(BrandFixture.STARBUCKS.생성()), MemberFixture.KIM.생성(), true),
-    TEST_WISH5(ProductFixture.CAKE.브랜드_설정_생성(BrandFixture.EDIYA.생성()), MemberFixture.KIM.생성(), true),
-    TEST_WISH6(ProductFixture.COFFEE.브랜드_설정_생성(BrandFixture.STARBUCKS.생성()), MemberFixture.KIM.생성(), false);
+    TEST_WISH1(ProductFixture.TEST_PRODUCT.브랜드_설정_생성(BrandFixture.EDIYA.생성()), MemberFixture.KAKAO.생성(), true, 1L),
+    TEST_WISH2(ProductFixture.CAKE.브랜드_설정_생성(BrandFixture.STARBUCKS.생성()), MemberFixture.KAKAO.생성(), false, 2L),
+    TEST_WISH3(ProductFixture.COFFEE.브랜드_설정_생성(BrandFixture.EDIYA.생성()), MemberFixture.KAKAO.생성(), false, 3L),
+    TEST_WISH4(ProductFixture.TEST_PRODUCT.브랜드_설정_생성(BrandFixture.STARBUCKS.생성()), MemberFixture.KIM.생성(), true, 4L),
+    TEST_WISH5(ProductFixture.CAKE.브랜드_설정_생성(BrandFixture.EDIYA.생성()), MemberFixture.KIM.생성(), true, 5L),
+    TEST_WISH6(ProductFixture.COFFEE.브랜드_설정_생성(BrandFixture.STARBUCKS.생성()), MemberFixture.KIM.생성(), false, 6L);
     
     
     private final Product product;
     private final Member member;
     private final boolean isPublic;
+    private final Long wishId;
     
-    WishFixture(Product product, Member member, boolean isPublic) {
+    WishFixture(Product product, Member member, boolean isPublic, Long wishId) {
         this.product = product;
         this.member = member;
         this.isPublic = isPublic;
+        this.wishId = wishId;
     }
     
     public Member getMember() {
@@ -31,6 +33,7 @@ public enum WishFixture {
     }
     public  Wish 생성() {
         return Wish.builder()
+                .wishId(wishId)
                 .product(product)
                 .member(member)
                 .isPublic(isPublic)
@@ -39,6 +42,7 @@ public enum WishFixture {
     
     public  Wish 생성(Product product, Member member) {
         return Wish.builder()
+                .wishId(wishId)
                 .product(product)
                 .member(member)
                 .isPublic(isPublic)

--- a/src/test/java/org/kakaoshare/backend/fixture/WishFixture.java
+++ b/src/test/java/org/kakaoshare/backend/fixture/WishFixture.java
@@ -3,14 +3,13 @@ package org.kakaoshare.backend.fixture;
 import org.kakaoshare.backend.domain.member.entity.Member;
 import org.kakaoshare.backend.domain.product.entity.Product;
 import org.kakaoshare.backend.domain.wish.entity.Wish;
-
 public enum WishFixture {
-    TEST_WISH1(ProductFixture.TEST_PRODUCT.가격_설정_생성(5000L), MemberFixture.KAKAO.생성(), true),
-    TEST_WISH2(ProductFixture.CAKE.가격_설정_생성(4500L), MemberFixture.KAKAO.생성(), false),
-    TEST_WISH3(ProductFixture.COFFEE.가격_설정_생성(8000L), MemberFixture.KAKAO.생성(), false),
-    TEST_WISH4(ProductFixture.TEST_PRODUCT.가격_설정_생성(5000L), MemberFixture.KIM.생성(), true),
-    TEST_WISH5(ProductFixture.CAKE.가격_설정_생성(4500L), MemberFixture.KIM.생성(), true),
-    TEST_WISH6(ProductFixture.COFFEE.가격_설정_생성(8000L), MemberFixture.KIM.생성(), false);
+    TEST_WISH1(ProductFixture.TEST_PRODUCT.브랜드_설정_생성(BrandFixture.EDIYA.생성()), MemberFixture.KAKAO.생성(), true),
+    TEST_WISH2(ProductFixture.CAKE.브랜드_설정_생성(BrandFixture.STARBUCKS.생성()), MemberFixture.KAKAO.생성(), false),
+    TEST_WISH3(ProductFixture.COFFEE.브랜드_설정_생성(BrandFixture.EDIYA.생성()), MemberFixture.KAKAO.생성(), false),
+    TEST_WISH4(ProductFixture.TEST_PRODUCT.브랜드_설정_생성(BrandFixture.STARBUCKS.생성()), MemberFixture.KIM.생성(), true),
+    TEST_WISH5(ProductFixture.CAKE.브랜드_설정_생성(BrandFixture.EDIYA.생성()), MemberFixture.KIM.생성(), true),
+    TEST_WISH6(ProductFixture.COFFEE.브랜드_설정_생성(BrandFixture.STARBUCKS.생성()), MemberFixture.KIM.생성(), false);
     
     
     private final Product product;
@@ -27,7 +26,18 @@ public enum WishFixture {
         return member;
     }
     
-    public Wish 생성(Product product, Member member) {
+    public Product getProduct() {
+        return product;
+    }
+    public  Wish 생성() {
+        return Wish.builder()
+                .product(product)
+                .member(member)
+                .isPublic(isPublic)
+                .build();
+    }
+    
+    public  Wish 생성(Product product, Member member) {
         return Wish.builder()
                 .product(product)
                 .member(member)


### PR DESCRIPTION
## #️⃣연관된 이슈

close #100 #101 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 위시 중복 등록 버그 해결
- 위시 공개 범위 변경 API

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

- <img width="213" alt="image" src="https://github.com/KakaoFunding/back-end/assets/88381563/0520c3bf-d1f2-4d37-ac71-daba79f8c280">
- <img width="197" alt="image" src="https://github.com/KakaoFunding/back-end/assets/88381563/75c7bf7b-86ba-4106-96a5-863721ea5fed">

## 🙏리뷰 요구사항(선택)

- 위시 등록 이벤트를 담당하는 `WishService.handleWishReservation`에도 일부 변경내용이 있습니다. 이해 안가는 로직 있으시면 언급 부탁드립니다!
