### PR TITLE
펀딩 결제 기능 추가

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -5,6 +5,8 @@ import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
 import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
 import org.kakaoshare.backend.domain.funding.dto.RegisterRequest;
 import org.kakaoshare.backend.domain.funding.dto.RegisterResponse;
+import org.kakaoshare.backend.domain.funding.dto.preview.request.FundingPreviewRequest;
+import org.kakaoshare.backend.domain.funding.dto.preview.response.FundingPreviewResponse;
 import org.kakaoshare.backend.domain.funding.service.FundingService;
 import org.kakaoshare.backend.jwt.util.LoggedInMember;
 import org.springframework.data.domain.PageRequest;
@@ -44,5 +46,11 @@ public class FundingController {
         PageRequest pageRequest = PageRequest.of(page, size);
         FundingSliceResponse response = fundingService.getMyAllFundingProducts(providerId, pageRequest);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/funding/preview")
+    public ResponseEntity<?> preview(@RequestBody final FundingPreviewRequest fundingPreviewRequest) {
+        final FundingPreviewResponse fundingPreviewResponse = fundingService.preview(fundingPreviewRequest);
+        return ResponseEntity.ok(fundingPreviewResponse);
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/request/FundingPreviewRequest.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/request/FundingPreviewRequest.java
@@ -1,0 +1,4 @@
+package org.kakaoshare.backend.domain.funding.dto.preview.request;
+
+public record FundingPreviewRequest(Long fundingId, Long attributeAmount) {
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/request/FundingProductDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/request/FundingProductDto.java
@@ -1,0 +1,6 @@
+package org.kakaoshare.backend.domain.funding.dto.preview.request;
+
+public record FundingProductDto(Long remainAmount, Long productId) {
+    public FundingProductDto {
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewAmount.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewAmount.java
@@ -1,6 +1,14 @@
 package org.kakaoshare.backend.domain.funding.dto.preview.response;
 
+import org.kakaoshare.backend.domain.funding.exception.FundingErrorCode;
+import org.kakaoshare.backend.domain.funding.exception.FundingException;
+
 public record FundingPreviewAmount(Long totalAmount, Long remainAmount, Long attributeAmount) {
+    public FundingPreviewAmount {
+        if (remainAmount < 0) {
+            throw new FundingException(FundingErrorCode.INVALID_ACCUMULATE_AMOUNT);
+        }
+    }
     public static FundingPreviewAmount of(final Long totalAmount, final Long attributeAmount) {
         return new FundingPreviewAmount(totalAmount, totalAmount - attributeAmount, attributeAmount);
     }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewAmount.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewAmount.java
@@ -1,0 +1,7 @@
+package org.kakaoshare.backend.domain.funding.dto.preview.response;
+
+public record FundingPreviewAmount(Long totalAmount, Long remainAmount, Long attributeAmount) {
+    public static FundingPreviewAmount of(final Long totalAmount, final Long attributeAmount) {
+        return new FundingPreviewAmount(totalAmount, totalAmount - attributeAmount, attributeAmount);
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewResponse.java
@@ -1,0 +1,18 @@
+package org.kakaoshare.backend.domain.funding.dto.preview.response;
+
+import org.kakaoshare.backend.domain.product.dto.ProductDto;
+
+import java.util.List;
+
+public record FundingPreviewResponse(Long productId, String name, String photo, List<String> optionNames, FundingPreviewAmount amount) {
+
+    public static FundingPreviewResponse of(final ProductDto productDto, final Long attributeAmount) {
+        return new FundingPreviewResponse(
+                productDto.getProductId(),
+                productDto.getName(),
+                productDto.getPhoto(),
+                null,   // TODO: 4/20/24 Funding 에 옵션 관련 컬럼이 없어 null로 대체
+                FundingPreviewAmount.of(productDto.getPrice(), attributeAmount)
+        );
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/entity/Funding.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/entity/Funding.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
@@ -57,13 +58,26 @@ public class Funding extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
-    
-    public Funding(Member member, Product product, Long goalAmount, LocalDate expiredAt) {
+
+    @Builder
+    public Funding(final Long fundingId,
+                   final Member member,
+                   final Product product,
+                   final Long goalAmount,
+                   final LocalDate expiredAt) {
+        this.fundingId = fundingId;
         this.member = member;
         this.product = product;
         this.goalAmount = goalAmount;
         this.expiredAt = expiredAt;
         this.status = "ACTIVE"; // 초기 상태 설정
+    }
+
+    public Funding(final Member member,
+                   final Product product,
+                   final Long goalAmount,
+                   final LocalDate expiredAt) {
+        this(null, member, product, goalAmount, expiredAt);
     }
 
     public void increaseAccumulateAmount(final Long amount) {

--- a/src/main/java/org/kakaoshare/backend/domain/funding/entity/Funding.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/entity/Funding.java
@@ -65,4 +65,23 @@ public class Funding extends BaseTimeEntity {
         this.expiredAt = expiredAt;
         this.status = "ACTIVE"; // 초기 상태 설정
     }
+
+    public void increaseAccumulateAmount(final Long amount) {
+        if (amount != null) {
+            this.accumulateAmount += amount;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Funding{" +
+                "fundingId=" + fundingId +
+                ", status='" + status + '\'' +
+                ", expiredAt=" + expiredAt +
+                ", goalAmount=" + goalAmount +
+                ", accumulateAmount=" + accumulateAmount +
+                ", member=" + member +
+                ", product=" + product +
+                '}';
+    }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/entity/FundingDetail.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/entity/FundingDetail.java
@@ -1,5 +1,6 @@
 package org.kakaoshare.backend.domain.funding.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,16 +11,21 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.kakaoshare.backend.domain.base.entity.BaseTimeEntity;
+import org.kakaoshare.backend.domain.member.entity.Member;
+import org.kakaoshare.backend.domain.payment.entity.Payment;
 
 import java.math.BigDecimal;
 
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
-        indexes = {@Index(name = "idx_funding_detail_funding_id",columnList = "funding_id",unique = true)}
+        indexes = {@Index(name = "idx_funding_detail_funding_id", columnList = "funding_id")}
 )
 public class FundingDetail extends BaseTimeEntity {
 
@@ -27,8 +33,12 @@ public class FundingDetail extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long fundingDetailId;
 
-    @Column(nullable = false, precision = 12, scale = 2)
-    private BigDecimal amount;
+    @Column(nullable = false)
+    private Long amount;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(nullable = false, precision = 7, scale = 2)
     private BigDecimal rate;
@@ -37,5 +47,35 @@ public class FundingDetail extends BaseTimeEntity {
     @JoinColumn(name = "funding_id", nullable = false)
     private Funding funding;
 
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "payment_id", nullable = false)
+    private Payment payment;
 
+    public FundingDetail(final Member member,
+                         final Funding funding,
+                         final Payment payment) {
+        this.member = member;
+        this.amount = payment.getTotalPrice();
+        this.rate = BigDecimal.valueOf(100 * amount / funding.getGoalAmount());
+        this.funding = funding;
+        this.payment = payment;
+    }
+
+    public void increaseAmountAndRate(final Long amount) {
+        if (amount != null) {
+            this.rate = this.rate.add(BigDecimal.valueOf(100 * amount / funding.getGoalAmount()));
+            this.amount += amount;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "FundingDetail{" +
+                "fundingDetailId=" + fundingDetailId +
+                ", amount=" + amount +
+                ", rate=" + rate +
+                ", funding=" + funding +
+                ", payment=" + payment +
+                '}';
+    }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/entity/FundingDetail.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/entity/FundingDetail.java
@@ -18,8 +18,6 @@ import org.kakaoshare.backend.domain.base.entity.BaseTimeEntity;
 import org.kakaoshare.backend.domain.member.entity.Member;
 import org.kakaoshare.backend.domain.payment.entity.Payment;
 
-import java.math.BigDecimal;
-
 
 @Entity
 @Getter
@@ -40,8 +38,8 @@ public class FundingDetail extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Column(nullable = false, precision = 7, scale = 2)
-    private BigDecimal rate;
+    @Column(nullable = false)
+    private Double rate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "funding_id", nullable = false)
@@ -56,16 +54,20 @@ public class FundingDetail extends BaseTimeEntity {
                          final Payment payment) {
         this.member = member;
         this.amount = payment.getTotalPrice();
-        this.rate = BigDecimal.valueOf(100 * amount / funding.getGoalAmount());
+        this.rate = calculateRate(this.amount);
         this.funding = funding;
         this.payment = payment;
     }
 
     public void increaseAmountAndRate(final Long amount) {
         if (amount != null) {
-            this.rate = this.rate.add(BigDecimal.valueOf(100 * amount / funding.getGoalAmount()));
+            this.rate += calculateRate(amount);
             this.amount += amount;
         }
+    }
+
+    private double calculateRate(final Long amount) {
+        return 100. * amount / funding.getGoalAmount();
     }
 
     @Override

--- a/src/main/java/org/kakaoshare/backend/domain/funding/entity/FundingDetail.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/entity/FundingDetail.java
@@ -54,9 +54,9 @@ public class FundingDetail extends BaseTimeEntity {
                          final Payment payment) {
         this.member = member;
         this.amount = payment.getTotalPrice();
-        this.rate = calculateRate(this.amount);
         this.funding = funding;
         this.payment = payment;
+        this.rate = calculateRate(this.amount);
     }
 
     public void increaseAmountAndRate(final Long amount) {

--- a/src/main/java/org/kakaoshare/backend/domain/funding/exception/FundingErrorCode.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/exception/FundingErrorCode.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public enum FundingErrorCode {
     INVALID_ACCUMULATE_AMOUNT("기여 금액은 잔여 금액보다 클 수 없습니다."),
+    INVALID_ATTRIBUTE_AMOUNT("기여 금액이 잘못되었습니다."),
     NOT_FOUND("펀딩 내역을 찾을 수 없습니다.");
 
     private final String message;

--- a/src/main/java/org/kakaoshare/backend/domain/funding/exception/FundingErrorCode.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/exception/FundingErrorCode.java
@@ -1,0 +1,15 @@
+package org.kakaoshare.backend.domain.funding.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum FundingErrorCode {
+    INVALID_ACCUMULATE_AMOUNT("기여 금액은 잔여 금액보다 클 수 없습니다."),
+    NOT_FOUND("펀딩 내역을 찾을 수 없습니다.");
+
+    private final String message;
+
+    FundingErrorCode(final String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/exception/FundingException.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/exception/FundingException.java
@@ -1,0 +1,10 @@
+package org.kakaoshare.backend.domain.funding.exception;
+
+public class FundingException extends RuntimeException {
+    private final FundingErrorCode errorCode;
+
+    public FundingException(final FundingErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingDetailRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingDetailRepository.java
@@ -1,8 +1,13 @@
 package org.kakaoshare.backend.domain.funding.repository;
 
+import org.kakaoshare.backend.domain.funding.entity.Funding;
 import org.kakaoshare.backend.domain.funding.entity.FundingDetail;
+import org.kakaoshare.backend.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 
 public interface FundingDetailRepository extends JpaRepository<FundingDetail, Long> {
+    Optional<FundingDetail> findByFundingAndMember(final Funding funding, final Member member);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingRepository.java
@@ -1,12 +1,17 @@
 package org.kakaoshare.backend.domain.funding.repository;
 
-import java.util.List;
-import java.util.Optional;
+import org.kakaoshare.backend.domain.funding.dto.preview.request.FundingProductDto;
 import org.kakaoshare.backend.domain.funding.entity.Funding;
 import org.kakaoshare.backend.domain.funding.repository.query.FundingRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 
 public interface FundingRepository extends JpaRepository<Funding, Long>, FundingRepositoryCustom {
-
+    @Query("SELECT NEW org.kakaoshare.backend.domain.funding.dto.preview.request.FundingProductDto(f.goalAmount - f.accumulateAmount, f.product.productId) " +
+            "FROM Funding f " +
+            "WHERE f.fundingId =:fundingId")
+    Optional<FundingProductDto> findAccumulateAmountAndProductIdById(final Long fundingId);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
@@ -1,16 +1,20 @@
 package org.kakaoshare.backend.domain.funding.service;
 
 import lombok.RequiredArgsConstructor;
-import org.kakaoshare.backend.domain.funding.dto.FundingResponse;
-import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
-import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
-import org.kakaoshare.backend.domain.funding.dto.RegisterRequest;
-import org.kakaoshare.backend.domain.funding.dto.RegisterResponse;
+import org.kakaoshare.backend.domain.funding.dto.*;
+import org.kakaoshare.backend.domain.funding.dto.preview.request.FundingPreviewRequest;
+import org.kakaoshare.backend.domain.funding.dto.preview.request.FundingProductDto;
+import org.kakaoshare.backend.domain.funding.dto.preview.response.FundingPreviewResponse;
 import org.kakaoshare.backend.domain.funding.entity.Funding;
+import org.kakaoshare.backend.domain.funding.exception.FundingErrorCode;
+import org.kakaoshare.backend.domain.funding.exception.FundingException;
 import org.kakaoshare.backend.domain.funding.repository.FundingRepository;
 import org.kakaoshare.backend.domain.member.entity.Member;
 import org.kakaoshare.backend.domain.member.repository.MemberRepository;
+import org.kakaoshare.backend.domain.product.dto.ProductDto;
 import org.kakaoshare.backend.domain.product.entity.Product;
+import org.kakaoshare.backend.domain.product.exception.ProductErrorCode;
+import org.kakaoshare.backend.domain.product.exception.ProductException;
 import org.kakaoshare.backend.domain.product.repository.ProductRepository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -28,6 +32,7 @@ public class FundingService {
     private final ProductRepository productRepository;
     private final MemberRepository memberRepository;
 
+    @Transactional
     public RegisterResponse registerFundingItem(Long productId, String providerId, RegisterRequest request) {
         Product product = findProductById(productId);
         Member member = findMemberByProviderId(providerId);
@@ -68,6 +73,17 @@ public class FundingService {
                 .build();
     }
 
+    public FundingPreviewResponse preview(final FundingPreviewRequest fundingPreviewRequest) {
+        final Long fundingId = fundingPreviewRequest.fundingId();
+        final FundingProductDto fundingProductDto = findFundingProductDtoById(fundingId);
+        final Long attributeAmount = fundingPreviewRequest.attributeAmount();
+        validateAttributeAmount(fundingProductDto.remainAmount(), attributeAmount);
+
+        final Long productId = fundingProductDto.productId();
+        final ProductDto productDto = findProductDtoByProductId(productId);
+        return FundingPreviewResponse.of(productDto, attributeAmount);
+    }
+
     private Member findMemberByProviderId(String providerId) {
         return memberRepository.findMemberByProviderId(providerId)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid providerId"));
@@ -76,5 +92,21 @@ public class FundingService {
     private Product findProductById(Long productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid product ID"));
+    }
+
+    private FundingProductDto findFundingProductDtoById(final Long fundingId) {
+        return fundingRepository.findAccumulateAmountAndProductIdById(fundingId)
+                .orElseThrow(() -> new FundingException(FundingErrorCode.NOT_FOUND));
+    }
+
+    private ProductDto findProductDtoByProductId(final Long productId) {
+        return productRepository.findProductDtoById(productId)
+                .orElseThrow(() -> new ProductException(ProductErrorCode.NOT_FOUND_PRODUCT_ERROR));
+    }
+
+    private void validateAttributeAmount(final Long remainAmount, final Long attributeAmount) {
+        if (remainAmount < attributeAmount) {
+            throw new FundingException(FundingErrorCode.INVALID_ACCUMULATE_AMOUNT);
+        }
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/gift/entity/Gift.java
+++ b/src/main/java/org/kakaoshare/backend/domain/gift/entity/Gift.java
@@ -9,6 +9,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
@@ -43,6 +44,7 @@ public class Gift extends BaseTimeEntity {
     private LocalDateTime expiredAt;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "receipt_id", nullable = false)
     private Receipt receipt;
 
     protected Gift() {

--- a/src/main/java/org/kakaoshare/backend/domain/order/entity/Order.java
+++ b/src/main/java/org/kakaoshare/backend/domain/order/entity/Order.java
@@ -16,7 +16,6 @@ import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import org.kakaoshare.backend.domain.base.entity.BaseTimeEntity;
-import org.kakaoshare.backend.domain.funding.entity.FundingDetail;
 import org.kakaoshare.backend.domain.payment.entity.Payment;
 import org.kakaoshare.backend.domain.receipt.entity.Receipt;
 
@@ -37,10 +36,6 @@ public class Order extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private OrderStatus status = COMPLETE_PAYMENT;
-    
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "funding_detail_id")
-    private FundingDetail fundingDetail;
     
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "payment_id")
@@ -64,7 +59,6 @@ public class Order extends BaseTimeEntity {
         return "Order{" +
                 "ordersId=" + ordersId +
                 ", status=" + status +
-                ", fundingDetail=" + fundingDetail +
                 ", payment=" + payment +
                 ", receipt=" + receipt +
                 '}';

--- a/src/main/java/org/kakaoshare/backend/domain/payment/controller/PaymentController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/controller/PaymentController.java
@@ -2,6 +2,7 @@ package org.kakaoshare.backend.domain.payment.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.kakaoshare.backend.domain.payment.dto.preview.PaymentPreviewRequest;
+import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentFundingReadyRequest;
 import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyRequest;
 import org.kakaoshare.backend.domain.payment.dto.success.request.PaymentSuccessRequest;
 import org.kakaoshare.backend.domain.payment.service.PaymentService;
@@ -15,36 +16,37 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/payments")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class PaymentController {
     private final PaymentService paymentService;
 
-    @PostMapping("/preview")
+    @PostMapping("/payments/preview")
     public ResponseEntity<?> preview(@RequestBody final List<PaymentPreviewRequest> paymentPreviewRequests) {
         return ResponseEntity.ok(paymentService.preview(paymentPreviewRequests));
     }
 
-    @PostMapping("/ready")
+    @PostMapping("/payments/ready")
     public ResponseEntity<?> ready(@LoggedInMember final String providerId,
                                    @RequestBody final List<PaymentReadyRequest> requests) {
         return ResponseEntity.ok(paymentService.ready(providerId, requests));
     }
 
+    @PostMapping("/funding/payments/ready")
+    public ResponseEntity<?> ready(@LoggedInMember final String providerId,
+                                   @RequestBody final PaymentFundingReadyRequest paymentFundingReadyRequest) {
+        return ResponseEntity.ok(paymentService.readyFunding(providerId, paymentFundingReadyRequest));
+    }
+
     @PostMapping("/success")
     public ResponseEntity<?> success(@LoggedInMember final String providerId,
-                                     @RequestBody final PaymentSuccessRequest requests) {
-        return ResponseEntity.ok(paymentService.approve(providerId, requests));
+                                     @RequestBody final PaymentSuccessRequest paymentSuccessRequest) {
+        return ResponseEntity.ok(paymentService.approve(providerId, paymentSuccessRequest));
     }
 
-    // TODO: 3/15/24 결제 취소 및 실패 관련 API는 추후 추가 예정
-    @PostMapping("/cancel")
-    public void cancel() {
-
-    }
-
-    @PostMapping("/fail")
-    public void fail() {
-
+    @PostMapping("/funding/payments/success")
+    public ResponseEntity<?> successFunding(@LoggedInMember final String providerId,
+                                            @RequestBody final PaymentSuccessRequest paymentSuccessRequest) {
+        return ResponseEntity.ok(paymentService.approveFunding(providerId, paymentSuccessRequest));
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/payment/controller/PaymentController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/controller/PaymentController.java
@@ -38,7 +38,7 @@ public class PaymentController {
         return ResponseEntity.ok(paymentService.readyFunding(providerId, paymentFundingReadyRequest));
     }
 
-    @PostMapping("/success")
+    @PostMapping("/payments/success")
     public ResponseEntity<?> success(@LoggedInMember final String providerId,
                                      @RequestBody final PaymentSuccessRequest paymentSuccessRequest) {
         return ResponseEntity.ok(paymentService.approve(providerId, paymentSuccessRequest));

--- a/src/main/java/org/kakaoshare/backend/domain/payment/dto/FundingOrderDetail.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/dto/FundingOrderDetail.java
@@ -1,0 +1,9 @@
+package org.kakaoshare.backend.domain.payment.dto;
+
+import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentFundingReadyRequest;
+
+public record FundingOrderDetail(Long fundingId) {
+    public static FundingOrderDetail from(final PaymentFundingReadyRequest paymentFundingReadyRequest) {
+        return new FundingOrderDetail(paymentFundingReadyRequest.fundingId());
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/payment/dto/ready/request/PaymentFundingReadyRequest.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/dto/ready/request/PaymentFundingReadyRequest.java
@@ -1,0 +1,4 @@
+package org.kakaoshare.backend.domain.payment.dto.ready.request;
+
+public record PaymentFundingReadyRequest(Long fundingId, Integer amount) {
+}

--- a/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentService.java
@@ -151,6 +151,10 @@ public class PaymentService {
     private void validateTotalAmount(final List<PaymentReadyRequest> paymentReadyRequests) {
         final List<Long> productIds = extractedProductIds(paymentReadyRequests, PaymentReadyRequest::productId);
         final Map<Long, Long> priceByIds = productRepository.findAllPriceByIdsGroupById(productIds);
+        if (priceByIds.isEmpty()) {
+            throw new ProductException(ProductErrorCode.NOT_FOUND_PRODUCT_ERROR);
+        }
+
         final boolean isAllMatch = paymentReadyRequests.stream()
                 .anyMatch(paymentReadyRequest -> paymentReadyRequest.quantity() * priceByIds.get(paymentReadyRequest.productId()) == paymentReadyRequest.totalAmount());
         if (!isAllMatch) {

--- a/src/main/java/org/kakaoshare/backend/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/repository/ProductRepository.java
@@ -1,10 +1,13 @@
 package org.kakaoshare.backend.domain.product.repository;
 
+import org.kakaoshare.backend.domain.product.dto.ProductDto;
 import org.kakaoshare.backend.domain.product.dto.ProductSummaryResponse;
 import org.kakaoshare.backend.domain.product.entity.Product;
 import org.kakaoshare.backend.domain.product.repository.query.ProductRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
@@ -12,4 +15,9 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
             "FROM Product p " +
             "WHERE p.productId =:productId")
     ProductSummaryResponse findAllProductSummaryById(final Long productId);
+
+    @Query("SELECT NEW org.kakaoshare.backend.domain.product.dto.ProductDto(p.productId, p.name, p.photo, p.price) " +
+            "FROM Product p " +
+            "WHERE p.productId =:productId")
+    Optional<ProductDto> findProductDtoById(final Long productId);
 }

--- a/src/main/resources/db/migration/V4__modify_funding_detail_orders.sql
+++ b/src/main/resources/db/migration/V4__modify_funding_detail_orders.sql
@@ -1,0 +1,21 @@
+-- orders 에 funding_detail_id (FK) 제거
+ALTER TABLE orders
+    DROP FOREIGN KEY `FKa02760ybny4lgcvn2wvhtcb6b`;
+
+-- funding_detail 의 funding_id 인덱스의 UNIQUE 속성 제거
+ALTER TABLE funding_detail
+    DROP INDEX idx_funding_detail_funding_id;
+ALTER TABLE funding_detail
+    ADD INDEX idx_funding_detail_funding_id (`funding_id`);
+
+-- funding_detail 에 payment_id (FK) 추가
+ALTER TABLE funding_detail
+    ADD COLUMN `payment_id` BIGINT NOT NULL;
+ALTER TABLE funding_detail
+    ADD CONSTRAINT FK_FUNDINGDETAIL_ON_PAYMENT FOREIGN KEY (payment_id) REFERENCES payment (payment_id);
+
+-- funding_detail 에 member_id (FK) 추가
+ALTER TABLE funding_detail
+    ADD COLUMN `member_id` bigint NOT NULL;
+ALTER TABLE funding_detail
+    ADD CONSTRAINT FK_FUNDINGDETAIL_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id);

--- a/src/main/resources/db/migration/V4__modify_funding_detail_orders.sql
+++ b/src/main/resources/db/migration/V4__modify_funding_detail_orders.sql
@@ -19,3 +19,6 @@ ALTER TABLE funding_detail
     ADD COLUMN `member_id` bigint NOT NULL;
 ALTER TABLE funding_detail
     ADD CONSTRAINT FK_FUNDINGDETAIL_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id);
+
+ALTER TABLE funding_detail
+    MODIFY `rate` DOUBLE;

--- a/src/main/resources/db/migration/V4__modify_gift.sql
+++ b/src/main/resources/db/migration/V4__modify_gift.sql
@@ -1,0 +1,5 @@
+ALTER TABLE gift
+    DROP COLUMN `receipt_id`;
+
+ALTER TABLE gift
+    CHANGE receipt_receipt_id `receipt_id`  BIGINT NOT NULL;

--- a/src/test/java/org/kakaoshare/backend/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/payment/service/PaymentServiceTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kakaoshare.backend.common.util.RedisUtils;
 import org.kakaoshare.backend.domain.brand.entity.Brand;
+import org.kakaoshare.backend.domain.funding.entity.Funding;
+import org.kakaoshare.backend.domain.funding.repository.FundingDetailRepository;
+import org.kakaoshare.backend.domain.funding.repository.FundingRepository;
 import org.kakaoshare.backend.domain.gift.repository.GiftRepository;
 import org.kakaoshare.backend.domain.member.entity.Member;
 import org.kakaoshare.backend.domain.member.repository.MemberRepository;
@@ -12,12 +15,14 @@ import org.kakaoshare.backend.domain.option.repository.OptionDetailRepository;
 import org.kakaoshare.backend.domain.option.repository.OptionRepository;
 import org.kakaoshare.backend.domain.order.dto.OrderSummaryResponse;
 import org.kakaoshare.backend.domain.order.repository.OrderRepository;
+import org.kakaoshare.backend.domain.payment.dto.FundingOrderDetail;
 import org.kakaoshare.backend.domain.payment.dto.OrderDetail;
 import org.kakaoshare.backend.domain.payment.dto.OrderDetails;
 import org.kakaoshare.backend.domain.payment.dto.approve.response.Amount;
 import org.kakaoshare.backend.domain.payment.dto.approve.response.KakaoPayApproveResponse;
 import org.kakaoshare.backend.domain.payment.dto.preview.PaymentPreviewRequest;
 import org.kakaoshare.backend.domain.payment.dto.preview.PaymentPreviewResponse;
+import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentFundingReadyRequest;
 import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyProductDto;
 import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyRequest;
 import org.kakaoshare.backend.domain.payment.dto.ready.response.KakaoPayReadyResponse;
@@ -43,7 +48,9 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kakaoshare.backend.fixture.BrandFixture.STARBUCKS;
+import static org.kakaoshare.backend.fixture.FundingFixture.SAMPLE_FUNDING;
 import static org.kakaoshare.backend.fixture.MemberFixture.KAKAO;
+import static org.kakaoshare.backend.fixture.MemberFixture.KIM;
 import static org.kakaoshare.backend.fixture.ProductFixture.CAKE;
 import static org.kakaoshare.backend.fixture.ProductFixture.COFFEE;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,6 +58,12 @@ import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentServiceTest {
+    @Mock
+    private FundingRepository fundingRepository;
+
+    @Mock
+    private FundingDetailRepository fundingDetailRepository;
+
     @Mock
     private MemberRepository memberRepository;
 
@@ -132,17 +145,13 @@ class PaymentServiceTest {
 
         final Map<Long, Long> pricesByIds = Map.of(cake.getProductId(), cake.getPrice(), coffee.getProductId(), coffee.getPrice());
         final Map<Long, String> namesByIds = Map.of(cake.getProductId(), cake.getName(), coffee.getProductId(), coffee.getName());
-        final KakaoPayReadyResponse readyResponse = createReadyResponse();
+        final KakaoPayReadyResponse readyResponse = createKakaoReadyResponse();
         doReturn(orderDetailsKey).when(orderNumberProvider).createOrderDetailKey();
         doReturn(pricesByIds).when(productRepository).findAllPriceByIdsGroupById(List.of(cake.getProductId(), coffee.getProductId()));
         doReturn(namesByIds).when(productRepository).findAllNameByIdsGroupById(List.of(cake.getProductId(), coffee.getProductId()));
         doReturn(readyResponse).when(webClientService).ready(providerId, paymentReadyProductDtos, orderDetailsKey);
 
-        final PaymentReadyResponse expect = new PaymentReadyResponse(
-                readyResponse.tid(),
-                readyResponse.next_redirect_pc_url(),
-                orderDetailsKey
-        );
+        final PaymentReadyResponse expect = createPaymentReadyResponse(orderDetailsKey, readyResponse);
         final PaymentReadyResponse actual = paymentService.ready(providerId, readyRequests);
         assertThat(actual).isEqualTo(expect);   // TODO: 3/15/24 equals() 및 hashCode()가 재정의되있으므로 isEqualTo() 사용
     }
@@ -153,9 +162,7 @@ class PaymentServiceTest {
         final Member member = KAKAO.생성();
         final String providerId = member.getProviderId();
 
-        final String pgToken = "pgToken";
-        final String tid = "tid";
-        final String orderDetailKey = "orderDetailKey";
+
 
         final Brand brand = STARBUCKS.생성(1L);
 
@@ -174,6 +181,9 @@ class PaymentServiceTest {
                 )
         );
 
+        final String pgToken = "pgToken";
+        final String tid = "tid";
+        final String orderDetailKey = "orderDetailKey";
         final PaymentSuccessRequest paymentSuccessRequest = new PaymentSuccessRequest(orderDetailKey, pgToken, tid);
 
         final int totalAmount = (int) (cake.getPrice() * cakeStockQuantity + coffee.getPrice() * coffeeStockQuantity);
@@ -206,6 +216,59 @@ class PaymentServiceTest {
         assertThat(actual).isEqualTo(expect);   // TODO: 3/16/24 equals() 및 hashCode()가 재정의되있으므로 isEqualTo() 사용
     }
 
+    @Test
+    @DisplayName("펀딩 결제 준비")
+    public void readyFunding() throws Exception {
+        final String orderDetailsKey = "12345678";
+
+        final Member contributor = KIM.생성();
+        final Member creator = KAKAO.생성();
+        final String providerId = contributor.getProviderId();
+
+        final Product cake = CAKE.생성(1L);
+        final Funding funding = SAMPLE_FUNDING.생성(1L, creator, cake);
+
+        final PaymentFundingReadyRequest paymentFundingReadyRequest = new PaymentFundingReadyRequest(funding.getFundingId(), 200);
+        final PaymentReadyProductDto paymentReadyProductDto = new PaymentReadyProductDto(cake.getName(), 1, paymentFundingReadyRequest.amount());
+        final KakaoPayReadyResponse readyResponse = createKakaoReadyResponse();
+
+        doReturn(orderDetailsKey).when(orderNumberProvider).createOrderDetailKey();
+        doReturn(Optional.of(funding)).when(fundingRepository).findById(funding.getFundingId());
+        doReturn(readyResponse).when(webClientService).ready(providerId, List.of(paymentReadyProductDto), orderDetailsKey);
+        final PaymentReadyResponse expect = createPaymentReadyResponse(orderDetailsKey, readyResponse);
+        final PaymentReadyResponse actual = paymentService.readyFunding(providerId, paymentFundingReadyRequest);
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    @DisplayName("펀딩 결제 승인")
+    public void approveFunding() throws Exception {
+        final String pgToken = "pgToken";
+        final String tid = "tid";
+        final String orderDetailsKey = "12345678";
+
+        final Member contributor = KIM.생성();
+        final Member creator = KAKAO.생성();
+        final String providerId = contributor.getProviderId();
+        final Product cake = CAKE.생성(1L);
+
+        final PaymentSuccessRequest paymentSuccessRequest = createPaymentSuccessRequest(pgToken, tid, orderDetailsKey);
+        final KakaoPayApproveResponse approveResponse = createApproveResponse(tid, orderDetailsKey, providerId, 200, cake.getName(), 1);
+        doReturn(approveResponse).when(webClientService).approve(providerId, paymentSuccessRequest);
+
+        final FundingOrderDetail fundingOrderDetail = new FundingOrderDetail(1L);
+        final Funding funding = SAMPLE_FUNDING.생성(1L, creator, cake);
+        doReturn(fundingOrderDetail).when(redisUtils).remove(orderDetailsKey, FundingOrderDetail.class);
+        doReturn(Optional.of(funding)).when(fundingRepository).findById(funding.getFundingId());
+        doReturn(Optional.of(contributor)).when(memberRepository).findMemberByProviderId(providerId);
+
+        final PaymentSuccessResponse expect = new PaymentSuccessResponse(Receiver.from(creator), Collections.emptyList());
+        final PaymentSuccessResponse actual = paymentService.approveFunding(providerId, paymentSuccessRequest);
+
+        assertThat(actual).isEqualTo(expect);
+    }
+
     private Payment createPayment(final String paymentNumber,
                                   final int totalAmount) {
         return Payment.builder()
@@ -226,7 +289,7 @@ class PaymentServiceTest {
         );
     }
 
-    private KakaoPayReadyResponse createReadyResponse() {
+    private KakaoPayReadyResponse createKakaoReadyResponse() {
         return new KakaoPayReadyResponse(
                 "tid",
                 "app_redirect_url",
@@ -236,6 +299,20 @@ class PaymentServiceTest {
                 null,
                 LocalDateTime.now()
         );
+    }
+
+    private PaymentReadyResponse createPaymentReadyResponse(final String orderDetailsKey, final KakaoPayReadyResponse readyResponse) {
+        return new PaymentReadyResponse(
+                readyResponse.tid(),
+                readyResponse.next_redirect_pc_url(),
+                orderDetailsKey
+        );
+    }
+
+    private PaymentSuccessRequest createPaymentSuccessRequest(final String pgToken,
+                                                              final String tid,
+                                                              final String orderDetailKey) {
+        return new PaymentSuccessRequest(orderDetailKey, pgToken, tid);
     }
 
     private KakaoPayApproveResponse createApproveResponse(final String tid,

--- a/src/test/java/org/kakaoshare/backend/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/payment/service/PaymentServiceTest.java
@@ -261,6 +261,7 @@ class PaymentServiceTest {
         final Funding funding = SAMPLE_FUNDING.생성(1L, creator, cake);
         doReturn(fundingOrderDetail).when(redisUtils).remove(orderDetailsKey, FundingOrderDetail.class);
         doReturn(Optional.of(funding)).when(fundingRepository).findById(funding.getFundingId());
+        doReturn(Optional.empty()).when(fundingDetailRepository).findByFundingAndMember(funding, contributor);
         doReturn(Optional.of(contributor)).when(memberRepository).findMemberByProviderId(providerId);
 
         final PaymentSuccessResponse expect = new PaymentSuccessResponse(Receiver.from(creator), Collections.emptyList());

--- a/src/test/java/org/kakaoshare/backend/fixture/FundingFixture.java
+++ b/src/test/java/org/kakaoshare/backend/fixture/FundingFixture.java
@@ -1,38 +1,48 @@
-//package org.kakaoshare.backend.fixture;
-//
-//import java.math.BigDecimal;
-//import java.time.LocalDate;
-//import org.kakaoshare.backend.domain.funding.entity.Funding;
-//import org.kakaoshare.backend.domain.member.entity.Member;
-//import org.kakaoshare.backend.domain.product.entity.Product;
-//
-//public enum FundingFixture {
-//    SAMPLE_FUNDING("ACTIVE", LocalDate.now().plusDays(30), new BigDecimal("1000.00"), new BigDecimal("500.00")),
-//    SAMPLE_FUNDING2("ACTIVE", LocalDate.now().plusDays(30), new BigDecimal("1000.00"), new BigDecimal("500.00"));
-//
-//    private final String status;
-//    private final LocalDate expiredAt;
-//    private final BigDecimal goalAmount;
-//    private final BigDecimal accumulateAmount;
-//
-//    FundingFixture(final String status,
-//                   final LocalDate expiredAt,
-//                   final BigDecimal goalAmount,
-//                   final BigDecimal accumulateAmount) {
-//        this.status = status;
-//        this.expiredAt = expiredAt;
-//        this.goalAmount = goalAmount;
-//        this.accumulateAmount = accumulateAmount;
-//    }
-//
-//    public Funding 생성(Member member, Product product) {
-//        return Funding.builder()
-//                .status(this.status)
-//                .expiredAt(this.expiredAt)
-//                .goalAmount(this.goalAmount)
-//                .accumulateAmount(this.accumulateAmount)
-//                .member(member)
-//                .product(product)
-//                .build();
-//    }
-//}
+package org.kakaoshare.backend.fixture;
+
+import org.kakaoshare.backend.domain.funding.entity.Funding;
+import org.kakaoshare.backend.domain.member.entity.Member;
+import org.kakaoshare.backend.domain.product.entity.Product;
+
+import java.time.LocalDate;
+
+public enum FundingFixture {
+    SAMPLE_FUNDING(LocalDate.now().plusDays(30), 1_000L, 500L);
+    private final LocalDate expiredAt;
+    private final Long goalAmount;
+    private final Long accumulateAmount;
+
+    FundingFixture(final LocalDate expiredAt,
+                   final Long goalAmount,
+                   final Long accumulateAmount) {
+        this.expiredAt = expiredAt;
+        this.goalAmount = goalAmount;
+        this.accumulateAmount = accumulateAmount;
+    }
+
+    public Funding 생성(final Member member,
+                      final Product product) {
+        final Funding funding = Funding.builder()
+                .expiredAt(expiredAt)
+                .goalAmount(goalAmount)
+                .member(member)
+                .product(product)
+                .build();
+        funding.increaseAccumulateAmount(accumulateAmount);
+        return funding;
+    }
+
+    public Funding 생성(final Long fundingId,
+                      final Member member,
+                      final Product product) {
+        final Funding funding = Funding.builder()
+                .fundingId(fundingId)
+                .expiredAt(expiredAt)
+                .goalAmount(goalAmount)
+                .member(member)
+                .product(product)
+                .build();
+        funding.increaseAccumulateAmount(accumulateAmount);
+        return funding;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #96 

## 📝작업 내용
- 펀딩 주문 페이지 로직 추가
- 펀딩 결제 로직 추가
- `Order` 엔티티 수정
  - `FundingDetail` 연관관계 제거
- `FundingDetail` 엔티티 수정
  - `Payment` 와 연관관계 추가
  - `Member` 와 연관관계 추가
  - `Funding` 인덱스 UNIQUE 속성 제거

## ✅테스트 결과

### Controller
- 포스트맨 참고

### Service
<img width="443" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/8a4481ab-cf1c-4c82-838e-f5359c3789da">
