### PR TITLE
상대방에게 선물 기능 추가

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/payment/controller/PaymentController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/controller/PaymentController.java
@@ -3,7 +3,7 @@ package org.kakaoshare.backend.domain.payment.controller;
 import lombok.RequiredArgsConstructor;
 import org.kakaoshare.backend.domain.payment.dto.preview.PaymentPreviewRequest;
 import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentFundingReadyRequest;
-import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyRequest;
+import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentGiftReadyRequest;
 import org.kakaoshare.backend.domain.payment.dto.success.request.PaymentSuccessRequest;
 import org.kakaoshare.backend.domain.payment.service.PaymentService;
 import org.kakaoshare.backend.jwt.util.LoggedInMember;
@@ -28,8 +28,8 @@ public class PaymentController {
 
     @PostMapping("/payments/ready")
     public ResponseEntity<?> ready(@LoggedInMember final String providerId,
-                                   @RequestBody final List<PaymentReadyRequest> requests) {
-        return ResponseEntity.ok(paymentService.ready(providerId, requests));
+                                   @RequestBody final PaymentGiftReadyRequest paymentGiftReadyRequest) {
+        return ResponseEntity.ok(paymentService.ready(providerId, paymentGiftReadyRequest));
     }
 
     @PostMapping("/funding/payments/ready")

--- a/src/main/java/org/kakaoshare/backend/domain/payment/dto/OrderDetails.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/dto/OrderDetails.java
@@ -12,9 +12,12 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class OrderDetails {
+    private String receiverProviderId;
     private List<OrderDetail> values;
 
-    public OrderDetails(final List<OrderDetail> values) {
+    public OrderDetails(final String receiverProviderId,
+                        final List<OrderDetail> values) {
+        this.receiverProviderId = receiverProviderId;
         this.values = values;
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/payment/dto/ready/request/PaymentGiftReadyItem.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/dto/ready/request/PaymentGiftReadyItem.java
@@ -4,7 +4,7 @@ import org.kakaoshare.backend.domain.payment.dto.OrderDetail;
 
 import java.util.List;
 
-public record PaymentReadyRequest(
+public record PaymentGiftReadyItem(
         Long productId, Integer totalAmount, Integer discountAmount,
         Integer quantity, List<Long> optionDetailIds) {
 

--- a/src/main/java/org/kakaoshare/backend/domain/payment/dto/ready/request/PaymentGiftReadyRequest.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/dto/ready/request/PaymentGiftReadyRequest.java
@@ -1,0 +1,7 @@
+package org.kakaoshare.backend.domain.payment.dto.ready.request;
+
+import java.util.List;
+
+public record PaymentGiftReadyRequest(String receiverProviderId,
+                                      List<PaymentGiftReadyItem> items) {
+}

--- a/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/payment/service/PaymentService.java
@@ -27,8 +27,9 @@ import org.kakaoshare.backend.domain.payment.dto.approve.response.KakaoPayApprov
 import org.kakaoshare.backend.domain.payment.dto.preview.PaymentPreviewRequest;
 import org.kakaoshare.backend.domain.payment.dto.preview.PaymentPreviewResponse;
 import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentFundingReadyRequest;
+import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentGiftReadyRequest;
 import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyProductDto;
-import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyRequest;
+import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentGiftReadyItem;
 import org.kakaoshare.backend.domain.payment.dto.ready.response.KakaoPayReadyResponse;
 import org.kakaoshare.backend.domain.payment.dto.ready.response.PaymentReadyResponse;
 import org.kakaoshare.backend.domain.payment.dto.success.request.PaymentSuccessRequest;
@@ -82,13 +83,16 @@ public class PaymentService {
     }
 
     public PaymentReadyResponse ready(final String providerId,
-                                      final List<PaymentReadyRequest> paymentReadyRequests) {
-        validateTotalAmount(paymentReadyRequests);
-        validateOptionDetailIds(paymentReadyRequests);
+                                      final PaymentGiftReadyRequest paymentGiftReadyRequest) {
+        final List<PaymentGiftReadyItem> paymentGiftReadyItems = paymentGiftReadyRequest.items();
+        validateTotalAmount(paymentGiftReadyItems);
+        validateOptionDetailIds(paymentGiftReadyItems);
+
         final String orderDetailKey = orderNumberProvider.createOrderDetailKey();
-        final OrderDetails orderDetails = getOrderDetails(paymentReadyRequests);
-        final List<PaymentReadyProductDto> paymentProductReadyRequests = getPaymentProductReadyRequests(paymentReadyRequests);
+        final List<PaymentReadyProductDto> paymentProductReadyRequests = getPaymentProductReadyRequests(paymentGiftReadyItems);
         final KakaoPayReadyResponse kakaoPayReadyResponse = webClientService.ready(providerId, paymentProductReadyRequests, orderDetailKey);
+
+        final OrderDetails orderDetails = getOrderDetails(paymentGiftReadyRequest);
         redisUtils.save(orderDetailKey, orderDetails);
         return new PaymentReadyResponse(kakaoPayReadyResponse.tid(), kakaoPayReadyResponse.next_redirect_pc_url(), orderDetailKey);
     }
@@ -111,12 +115,16 @@ public class PaymentService {
                                           final PaymentSuccessRequest paymentSuccessRequest) {
         final KakaoPayApproveResponse approveResponse = webClientService.approve(providerId, paymentSuccessRequest);
         final Payment payment = saveAndGetPayment(approveResponse);
-        final Member recipient = findMemberByProviderId(providerId); // TODO: 3/30/24 토큰에 저장된 값이 PK가 아니라 Member 엔티티를 가져와야 함
-        final Member receiver = findMemberByProviderId(providerId); // TODO: 3/28/24 친구목록이 구현되지 않아 나에게로 선물만 구현
         final OrderDetails orderDetails = redisUtils.remove(approveResponse.partner_order_id(), OrderDetails.class);
+
+        final String receiverProviderId = orderDetails.getReceiverProviderId();
+        final Member recipient = findMemberByProviderId(providerId); // TODO: 3/30/24 토큰에 저장된 값이 PK가 아니라 Member 엔티티를 가져와야 함
+        final Member receiver = findMemberByProviderId(receiverProviderId);
+
         final Receipts receipts = getReceipts(recipient.getMemberId(), receiver, orderDetails);
         saveGifts(receipts);
         saveOrders(payment, receipts);
+
         final List<OrderSummaryResponse> orderSummaries = getOrderSummaries(orderDetails);
         return new PaymentSuccessResponse(Receiver.from(receiver), orderSummaries);
     }
@@ -148,39 +156,39 @@ public class PaymentService {
                 .sum();
     }
 
-    private void validateTotalAmount(final List<PaymentReadyRequest> paymentReadyRequests) {
-        final List<Long> productIds = extractedProductIds(paymentReadyRequests, PaymentReadyRequest::productId);
+    private void validateTotalAmount(final List<PaymentGiftReadyItem> paymentGiftReadyItems) {
+        final List<Long> productIds = extractedProductIds(paymentGiftReadyItems, PaymentGiftReadyItem::productId);
         final Map<Long, Long> priceByIds = productRepository.findAllPriceByIdsGroupById(productIds);
         if (priceByIds.isEmpty()) {
             throw new ProductException(ProductErrorCode.NOT_FOUND_PRODUCT_ERROR);
         }
 
-        final boolean isAllMatch = paymentReadyRequests.stream()
-                .anyMatch(paymentReadyRequest -> paymentReadyRequest.quantity() * priceByIds.get(paymentReadyRequest.productId()) == paymentReadyRequest.totalAmount());
+        final boolean isAllMatch = paymentGiftReadyItems.stream()
+                .anyMatch(paymentGiftReadyItem -> paymentGiftReadyItem.quantity() * priceByIds.get(paymentGiftReadyItem.productId()) == paymentGiftReadyItem.totalAmount());
         if (!isAllMatch) {
             throw new PaymentException(INVALID_AMOUNT);
         }
     }
 
-    private List<PaymentReadyProductDto> getPaymentProductReadyRequests(final List<PaymentReadyRequest> paymentReadyRequests) {
-        final List<Long> productIds = extractedProductIds(paymentReadyRequests, PaymentReadyRequest::productId);
+    private List<PaymentReadyProductDto> getPaymentProductReadyRequests(final List<PaymentGiftReadyItem> paymentGiftReadyItems) {
+        final List<Long> productIds = extractedProductIds(paymentGiftReadyItems, PaymentGiftReadyItem::productId);
         final Map<Long, String> nameById = productRepository.findAllNameByIdsGroupById(productIds);
-        return paymentReadyRequests.stream()
-                .map(paymentReadyRequest -> new PaymentReadyProductDto(nameById.get(paymentReadyRequest.productId()), paymentReadyRequest.quantity(), paymentReadyRequest.totalAmount()))
+        return paymentGiftReadyItems.stream()
+                .map(paymentGiftReadyItem -> new PaymentReadyProductDto(nameById.get(paymentGiftReadyItem.productId()), paymentGiftReadyItem.quantity(), paymentGiftReadyItem.totalAmount()))
                 .toList();
     }
 
-    private void validateOptionDetailIds(final List<PaymentReadyRequest> paymentReadyRequests) {
-        final boolean isAllMatch = paymentReadyRequests.stream()
+    private void validateOptionDetailIds(final List<PaymentGiftReadyItem> paymentGiftReadyItems) {
+        final boolean isAllMatch = paymentGiftReadyItems.stream()
                 .anyMatch(this::matchesOptionsWithProduct);
         if (!isAllMatch) {
             throw new PaymentException(INVALID_OPTION);
         }
     }
 
-    private boolean matchesOptionsWithProduct(final PaymentReadyRequest paymentReadyRequest) {
-        final Long productId = paymentReadyRequest.productId();
-        final List<Long> optionDetailIds = paymentReadyRequest.optionDetailIds();
+    private boolean matchesOptionsWithProduct(final PaymentGiftReadyItem paymentGiftReadyItem) {
+        final Long productId = paymentGiftReadyItem.productId();
+        final List<Long> optionDetailIds = paymentGiftReadyItem.optionDetailIds();
         if (optionDetailIds == null || optionDetailIds.isEmpty()) {
             return true;
         }
@@ -197,11 +205,13 @@ public class PaymentService {
         return productIds.size() == 1 && productIds.get(0).equals(productId);
     }
 
-    private OrderDetails getOrderDetails(final List<PaymentReadyRequest> paymentReadyRequests) {
-        final List<OrderDetail> orderDetails = paymentReadyRequests.stream()
-                .map(paymentReadyRequest -> paymentReadyRequest.toOrderDetail(orderNumberProvider.createOrderNumber()))
+    private OrderDetails getOrderDetails(final PaymentGiftReadyRequest paymentGiftReadyRequest) {
+        final List<PaymentGiftReadyItem> paymentGiftReadyItems = paymentGiftReadyRequest.items();
+        final String receiverProviderId = paymentGiftReadyRequest.receiverProviderId();
+        final List<OrderDetail> orderDetails = paymentGiftReadyItems.stream()
+                .map(paymentGiftReadyItem -> paymentGiftReadyItem.toOrderDetail(orderNumberProvider.createOrderNumber()))
                 .toList();
-        return new OrderDetails(orderDetails);
+        return new OrderDetails(receiverProviderId, orderDetails);
     }
 
     private Payment saveAndGetPayment(final KakaoPayApproveResponse approveResponse) {

--- a/src/test/java/org/kakaoshare/backend/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/payment/service/PaymentServiceTest.java
@@ -23,8 +23,9 @@ import org.kakaoshare.backend.domain.payment.dto.approve.response.KakaoPayApprov
 import org.kakaoshare.backend.domain.payment.dto.preview.PaymentPreviewRequest;
 import org.kakaoshare.backend.domain.payment.dto.preview.PaymentPreviewResponse;
 import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentFundingReadyRequest;
+import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentGiftReadyRequest;
 import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyProductDto;
-import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentReadyRequest;
+import org.kakaoshare.backend.domain.payment.dto.ready.request.PaymentGiftReadyItem;
 import org.kakaoshare.backend.domain.payment.dto.ready.response.KakaoPayReadyResponse;
 import org.kakaoshare.backend.domain.payment.dto.ready.response.PaymentReadyResponse;
 import org.kakaoshare.backend.domain.payment.dto.success.request.PaymentSuccessRequest;
@@ -133,10 +134,11 @@ class PaymentServiceTest {
         final Product coffee = COFFEE.생성(2L);
         final int coffeeQuantity = 2;
 
-        final List<PaymentReadyRequest> readyRequests = List.of(
+        final List<PaymentGiftReadyItem> items = List.of(
                 createPaymentReadyRequest(cake, cakeQuantity),
                 createPaymentReadyRequest(coffee, coffeeQuantity)
         );
+        final PaymentGiftReadyRequest paymentGiftReadyRequest = new PaymentGiftReadyRequest(providerId, items);
 
         final List<PaymentReadyProductDto> paymentReadyProductDtos = List.of(
                 new PaymentReadyProductDto(cake.getName(), cakeQuantity, cake.getPrice().intValue()),
@@ -152,18 +154,15 @@ class PaymentServiceTest {
         doReturn(readyResponse).when(webClientService).ready(providerId, paymentReadyProductDtos, orderDetailsKey);
 
         final PaymentReadyResponse expect = createPaymentReadyResponse(orderDetailsKey, readyResponse);
-        final PaymentReadyResponse actual = paymentService.ready(providerId, readyRequests);
+        final PaymentReadyResponse actual = paymentService.ready(providerId, paymentGiftReadyRequest);
         assertThat(actual).isEqualTo(expect);   // TODO: 3/15/24 equals() 및 hashCode()가 재정의되있으므로 isEqualTo() 사용
     }
 
     @Test
     @DisplayName("결제 승인 (나에게 선물, 옵션 선택 X)")
-    public void approve() throws Exception {
+    public void approveToMe() throws Exception {
         final Member member = KAKAO.생성();
         final String providerId = member.getProviderId();
-
-
-
         final Brand brand = STARBUCKS.생성(1L);
 
         final Product cake = CAKE.생성(1L, brand);
@@ -175,6 +174,7 @@ class PaymentServiceTest {
         final String coffeeOrderNumber = "2222";
 
         final OrderDetails orderDetails = new OrderDetails(
+                providerId,
                 List.of(
                         new OrderDetail(cakeOrderNumber, cake.getProductId(), cakeStockQuantity, null),
                         new OrderDetail(coffeeOrderNumber, coffee.getProductId(), coffeeStockQuantity, null)
@@ -211,6 +211,68 @@ class PaymentServiceTest {
                 new OrderSummaryResponse(coffeeSummaryResponse, coffeeStockQuantity, Collections.emptyList())
         );
         final Receiver receiver = Receiver.from(member);
+        final PaymentSuccessResponse expect = new PaymentSuccessResponse(receiver, orderSummaries);
+        final PaymentSuccessResponse actual = paymentService.approve(providerId, paymentSuccessRequest);
+        assertThat(actual).isEqualTo(expect);   // TODO: 3/16/24 equals() 및 hashCode()가 재정의되있으므로 isEqualTo() 사용
+    }
+
+    @Test
+    @DisplayName("결제 승인 (친구에게 선물, 옵션 선택 X)")
+    public void approveToOther() throws Exception {
+        final Member recipientMember = KAKAO.생성();
+        final String providerId = recipientMember.getProviderId();
+        final Member receiverMember = KIM.생성();
+        final String receiverProviderId = receiverMember.getProviderId();
+
+        final Brand brand = STARBUCKS.생성(1L);
+
+        final Product cake = CAKE.생성(1L, brand);
+        final int cakeStockQuantity = 1;
+        final String cakeOrderNumber = "1111";
+
+        final Product coffee = COFFEE.생성(2L, brand);
+        final int coffeeStockQuantity = 1;
+        final String coffeeOrderNumber = "2222";
+
+        final OrderDetails orderDetails = new OrderDetails(
+                receiverProviderId,
+                List.of(
+                        new OrderDetail(cakeOrderNumber, cake.getProductId(), cakeStockQuantity, null),
+                        new OrderDetail(coffeeOrderNumber, coffee.getProductId(), coffeeStockQuantity, null)
+                )
+        );
+
+        final String pgToken = "pgToken";
+        final String tid = "tid";
+        final String orderDetailKey = "orderDetailKey";
+        final PaymentSuccessRequest paymentSuccessRequest = new PaymentSuccessRequest(orderDetailKey, pgToken, tid);
+
+        final int totalAmount = (int) (cake.getPrice() * cakeStockQuantity + coffee.getPrice() * coffeeStockQuantity);
+        final String itemName = cake.getName() + " 외 1건";
+
+        final KakaoPayApproveResponse approveResponse = createApproveResponse(tid, orderDetailKey, providerId, totalAmount, itemName, cakeStockQuantity + coffeeStockQuantity);
+        final Payment payment = createPayment(tid, totalAmount);
+
+        doReturn(orderDetails).when(redisUtils).remove(orderDetailKey, OrderDetails.class);
+        doReturn(approveResponse).when(webClientService).approve(providerId, paymentSuccessRequest);
+        doReturn(payment).when(paymentRepository).save(any());  // TODO: 3/16/24 save() 에서 new로 다른 객체가 생성되므로 any()로 대체
+        doReturn(Optional.of(recipientMember)).when(memberRepository).findMemberByProviderId(providerId);
+        doReturn(Optional.of(receiverMember)).when(memberRepository).findMemberByProviderId(receiverProviderId);
+        doReturn(cake).when(productRepository).getReferenceById(cake.getProductId());
+        doReturn(coffee).when(productRepository).getReferenceById(coffee.getProductId());
+        doReturn(null).when(giftRepository).saveAll(any());
+        doReturn(null).when(orderRepository).saveAll(any());  // TODO: 3/16/24 saveAll() 에서 new로 다른 객체가 생성되므로 any()로 대체
+
+        final ProductSummaryResponse cakeSummaryResponse = new ProductSummaryResponse(brand.getName(), cake.getName(), cake.getPrice() * cakeStockQuantity);
+        final ProductSummaryResponse coffeeSummaryResponse = new ProductSummaryResponse(brand.getName(), coffee.getName(), coffee.getPrice() * coffeeStockQuantity);
+        doReturn(cakeSummaryResponse).when(productRepository).findAllProductSummaryById(cake.getProductId());
+        doReturn(coffeeSummaryResponse).when(productRepository).findAllProductSummaryById(coffee.getProductId());
+
+        final List<OrderSummaryResponse> orderSummaries = List.of(
+                new OrderSummaryResponse(cakeSummaryResponse, cakeStockQuantity, Collections.emptyList()),
+                new OrderSummaryResponse(coffeeSummaryResponse, coffeeStockQuantity, Collections.emptyList())
+        );
+        final Receiver receiver = Receiver.from(receiverMember);
         final PaymentSuccessResponse expect = new PaymentSuccessResponse(receiver, orderSummaries);
         final PaymentSuccessResponse actual = paymentService.approve(providerId, paymentSuccessRequest);
         assertThat(actual).isEqualTo(expect);   // TODO: 3/16/24 equals() 및 hashCode()가 재정의되있으므로 isEqualTo() 사용
@@ -279,9 +341,9 @@ class PaymentServiceTest {
                 .build();
     }
 
-    private PaymentReadyRequest createPaymentReadyRequest(final Product product,
-                                                          final int quantity) {
-        return new PaymentReadyRequest(
+    private PaymentGiftReadyItem createPaymentReadyRequest(final Product product,
+                                                           final int quantity) {
+        return new PaymentGiftReadyItem(
                 product.getProductId(),
                 product.getPrice().intValue(),
                 0,


### PR DESCRIPTION
## #️⃣연관된 이슈

close #117

## 📝작업 내용
- 선물 결제 요청 DTO 수정
  - `PaymentReadyRequest` -> `PaymentGiftReadyItem` 으로 이름 변경
  - `PaymentGiftReadyRequest` 추가
    - `List<PaymentGiftReadyItem>`, `receiverProviderId` 를 필드로 가짐
- 기존 선물 결제 요청 파라미터 수정
  - `PaymentReadyRequest` -> `PaymentGiftReadyRequest`로 변경
- `OrderDetails` 필드 추가
  - 결제 준비~승인 과정에서 받는 사람 `providerId`를 캐싱해야 하므로  `receiverProviderId` 필드 추가

## ✅테스트 결과
### Controller 
- Postman 참고

### Service
<img width="444" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/c27ee318-338a-431a-bd03-998250eaddb8">

### 로컬에서 Postman을 통해 결제 후 Receipt 테이블 결과
<img width="1237" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/9c85df84-fdd1-4d72-ba9f-a185b29d44a2">
- `recipient_id`, `receiver_id`가 정상적으로 삽입
