### PR TITLE
펀딩 결제 페이지 요청/응답 Body 수정, ProductDto에 brandName 필드 추가

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/request/FundingPreviewRequest.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/request/FundingPreviewRequest.java
@@ -1,4 +1,4 @@
 package org.kakaoshare.backend.domain.funding.dto.preview.request;
 
-public record FundingPreviewRequest(Long fundingId, Long attributeAmount) {
+public record FundingPreviewRequest(Long fundingId) {
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/request/FundingProductDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/request/FundingProductDto.java
@@ -1,6 +1,6 @@
 package org.kakaoshare.backend.domain.funding.dto.preview.request;
 
-public record FundingProductDto(Long remainAmount, Long productId) {
+public record FundingProductDto(Long goalAmount, Long remainAmount, Long productId) {
     public FundingProductDto {
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewAmount.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewAmount.java
@@ -1,4 +1,4 @@
 package org.kakaoshare.backend.domain.funding.dto.preview.response;
 
-public record FundingPreviewAmount(Long goalAmount, Long remainAmount) {
+public record FundingPreviewAmount(Long productAmount, Long goalAmount, Long remainAmount) {
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewAmount.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewAmount.java
@@ -1,15 +1,4 @@
 package org.kakaoshare.backend.domain.funding.dto.preview.response;
 
-import org.kakaoshare.backend.domain.funding.exception.FundingErrorCode;
-import org.kakaoshare.backend.domain.funding.exception.FundingException;
-
-public record FundingPreviewAmount(Long totalAmount, Long remainAmount, Long attributeAmount) {
-    public FundingPreviewAmount {
-        if (remainAmount < 0) {
-            throw new FundingException(FundingErrorCode.INVALID_ACCUMULATE_AMOUNT);
-        }
-    }
-    public static FundingPreviewAmount of(final Long totalAmount, final Long attributeAmount) {
-        return new FundingPreviewAmount(totalAmount, totalAmount - attributeAmount, attributeAmount);
-    }
+public record FundingPreviewAmount(Long goalAmount, Long remainAmount) {
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewResponse.java
@@ -1,18 +1,20 @@
 package org.kakaoshare.backend.domain.funding.dto.preview.response;
 
+import org.kakaoshare.backend.domain.funding.dto.preview.request.FundingProductDto;
 import org.kakaoshare.backend.domain.product.dto.ProductDto;
 
 import java.util.List;
 
 public record FundingPreviewResponse(Long productId, String name, String photo, List<String> optionNames, FundingPreviewAmount amount) {
 
-    public static FundingPreviewResponse of(final ProductDto productDto, final Long attributeAmount) {
+    public static FundingPreviewResponse of(final ProductDto productDto,
+                                            final FundingProductDto fundingProductDto) {
         return new FundingPreviewResponse(
                 productDto.getProductId(),
                 productDto.getName(),
                 productDto.getPhoto(),
                 null,   // TODO: 4/20/24 Funding 에 옵션 관련 컬럼이 없어 null로 대체
-                FundingPreviewAmount.of(productDto.getPrice(), attributeAmount)
+                new FundingPreviewAmount(fundingProductDto.goalAmount(), fundingProductDto.remainAmount())
         );
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewResponse.java
@@ -5,12 +5,13 @@ import org.kakaoshare.backend.domain.product.dto.ProductDto;
 
 import java.util.List;
 
-public record FundingPreviewResponse(Long productId, String name, String photo, List<String> optionNames, FundingPreviewAmount amount) {
+public record FundingPreviewResponse(Long productId, String brandName, String name, String photo, List<String> optionNames, FundingPreviewAmount amount) {
 
     public static FundingPreviewResponse of(final ProductDto productDto,
                                             final FundingProductDto fundingProductDto) {
         return new FundingPreviewResponse(
                 productDto.getProductId(),
+                productDto.getBrandName(),
                 productDto.getName(),
                 productDto.getPhoto(),
                 null,   // TODO: 4/20/24 Funding 에 옵션 관련 컬럼이 없어 null로 대체

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/preview/response/FundingPreviewResponse.java
@@ -14,7 +14,7 @@ public record FundingPreviewResponse(Long productId, String name, String photo, 
                 productDto.getName(),
                 productDto.getPhoto(),
                 null,   // TODO: 4/20/24 Funding 에 옵션 관련 컬럼이 없어 null로 대체
-                new FundingPreviewAmount(fundingProductDto.goalAmount(), fundingProductDto.remainAmount())
+                new FundingPreviewAmount(productDto.getPrice(), fundingProductDto.goalAmount(), fundingProductDto.remainAmount())
         );
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 
 public interface FundingRepository extends JpaRepository<Funding, Long>, FundingRepositoryCustom {
-    @Query("SELECT NEW org.kakaoshare.backend.domain.funding.dto.preview.request.FundingProductDto(f.goalAmount - f.accumulateAmount, f.product.productId) " +
+    @Query("SELECT NEW org.kakaoshare.backend.domain.funding.dto.preview.request.FundingProductDto(f.goalAmount, f.goalAmount - f.accumulateAmount, f.product.productId) " +
             "FROM Funding f " +
             "WHERE f.fundingId =:fundingId")
     Optional<FundingProductDto> findAccumulateAmountAndProductIdById(@Param("fundingId") final Long fundingId);

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
@@ -76,12 +76,9 @@ public class FundingService {
     public FundingPreviewResponse preview(final FundingPreviewRequest fundingPreviewRequest) {
         final Long fundingId = fundingPreviewRequest.fundingId();
         final FundingProductDto fundingProductDto = findFundingProductDtoById(fundingId);
-        final Long attributeAmount = fundingPreviewRequest.attributeAmount();
-        validateAttributeAmount(fundingProductDto.remainAmount(), attributeAmount);
-
         final Long productId = fundingProductDto.productId();
         final ProductDto productDto = findProductDtoByProductId(productId);
-        return FundingPreviewResponse.of(productDto, attributeAmount);
+        return FundingPreviewResponse.of(productDto, fundingProductDto);
     }
 
     private Member findMemberByProviderId(String providerId) {
@@ -102,11 +99,5 @@ public class FundingService {
     private ProductDto findProductDtoByProductId(final Long productId) {
         return productRepository.findProductDtoById(productId)
                 .orElseThrow(() -> new ProductException(ProductErrorCode.NOT_FOUND_PRODUCT_ERROR));
-    }
-
-    private void validateAttributeAmount(final Long remainAmount, final Long attributeAmount) {
-        if (remainAmount < attributeAmount) {
-            throw new FundingException(FundingErrorCode.INVALID_ACCUMULATE_AMOUNT);
-        }
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/product/dto/Product4DisplayDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/dto/Product4DisplayDto.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 
 @Getter
 public class Product4DisplayDto extends ProductDto {
-    private final String brandName;
     private final boolean isWished;
     private final Long wishCount;
 
@@ -14,8 +13,7 @@ public class Product4DisplayDto extends ProductDto {
                               final String photo, final Long price,
                               final String brandName, final Long wishCount,
                               final boolean isWished) {
-        super(productId, name, photo, price);
-        this.brandName = brandName;
+        super(productId, name, photo, price, brandName);
         this.wishCount = wishCount;
         this.isWished = isWished;
     }

--- a/src/main/java/org/kakaoshare/backend/domain/product/dto/ProductDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/dto/ProductDto.java
@@ -9,13 +9,16 @@ public class ProductDto {
     protected final String name;
     protected final String photo;
     protected final Long price;
-    
+    protected final String brandName;
+
     @QueryProjection
     public ProductDto(final Long productId, final String name,
-                       final String photo, final Long price) {
+                      final String photo, final Long price,
+                      final String brandName) {
         this.productId = productId;
         this.name = name;
         this.photo = photo;
         this.price = price;
+        this.brandName = brandName;
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/repository/ProductRepository.java
@@ -17,7 +17,7 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
             "WHERE p.productId =:productId")
     ProductSummaryResponse findAllProductSummaryById(@Param("productId") final Long productId);
 
-    @Query("SELECT NEW org.kakaoshare.backend.domain.product.dto.ProductDto(p.productId, p.name, p.photo, p.price) " +
+    @Query("SELECT NEW org.kakaoshare.backend.domain.product.dto.ProductDto(p.productId, p.name, p.photo, p.price, p.brandName) " +
             "FROM Product p " +
             "WHERE p.productId =:productId")
     Optional<ProductDto> findProductDtoById(@Param("productId") final Long productId);

--- a/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/repository/query/ProductRepositoryCustomImpl.java
@@ -43,7 +43,9 @@ import java.util.stream.Stream;
 import static com.querydsl.core.group.GroupBy.groupBy;
 import static com.querydsl.core.group.GroupBy.list;
 import static com.querydsl.jpa.JPAExpressions.select;
-import static org.kakaoshare.backend.common.util.RepositoryUtils.*;
+import static org.kakaoshare.backend.common.util.RepositoryUtils.containsExpression;
+import static org.kakaoshare.backend.common.util.RepositoryUtils.createOrderSpecifiers;
+import static org.kakaoshare.backend.common.util.RepositoryUtils.toPage;
 import static org.kakaoshare.backend.domain.brand.entity.QBrand.brand;
 import static org.kakaoshare.backend.domain.category.entity.QCategory.category;
 import static org.kakaoshare.backend.domain.product.entity.QProduct.product;
@@ -275,7 +277,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom, Sor
                 product.productId,
                 product.name,
                 product.photo,
-                product.price);
+                product.price,
+                product.brandName);
     }
     
     private BooleanExpression categoryIdEqualTo(final Long categoryId) {

--- a/src/test/java/org/kakaoshare/backend/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/order/service/OrderServiceTest.java
@@ -75,6 +75,6 @@ class OrderServiceTest {
     }
 
     private ProductDto getProductDto(final Product product) {
-        return new ProductDto(product.getProductId(), product.getName(), product.getPhoto(), product.getPrice());
+        return new ProductDto(product.getProductId(), product.getName(), product.getPhoto(), product.getPrice(), product.getBrandName());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #166

## 📝작업 내용
- 펀딩 결제 페이지(`funding/preview`)
 - 요청 Body에 기여 금액 제거
 - 응답 Body에 상품 금액 추가
 - 응답 Body에 브랜드명 추가
- `ProductDto` 에 `brandName` 필드 추가

## ✅테스트 결과
<img width="710" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/7f7f48cc-6e4d-445b-a4ed-d032468a0429">

