### PR TITLE
로그인 시 프로필 사진, ID 추가

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/authenticate/OAuthLoginMemberResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/authenticate/OAuthLoginMemberResponse.java
@@ -2,8 +2,12 @@ package org.kakaoshare.backend.domain.member.dto.oauth.authenticate;
 
 import org.kakaoshare.backend.domain.member.dto.oauth.profile.OAuthProfile;
 
-public record OAuthLoginMemberResponse(String profileUrl, String name) {
+public record OAuthLoginMemberResponse(String id, String profileUrl, String name) {
     public static OAuthLoginMemberResponse from(final OAuthProfile oAuthProfile) {
-        return new OAuthLoginMemberResponse(null, oAuthProfile.getName());
+        return new OAuthLoginMemberResponse(
+                oAuthProfile.getProviderId(),
+                oAuthProfile.getProfileImageUrl(),
+                oAuthProfile.getName()
+        );
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/authenticate/OAuthLoginMemberResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/authenticate/OAuthLoginMemberResponse.java
@@ -2,7 +2,7 @@ package org.kakaoshare.backend.domain.member.dto.oauth.authenticate;
 
 import org.kakaoshare.backend.domain.member.dto.oauth.profile.OAuthProfile;
 
-public record OAuthLoginMemberResponse(String id, String profileUrl, String name) {
+public record OAuthLoginMemberResponse(String providerId, String profileUrl, String name) {
     public static OAuthLoginMemberResponse from(final OAuthProfile oAuthProfile) {
         return new OAuthLoginMemberResponse(
                 oAuthProfile.getProviderId(),

--- a/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/profile/OAuthProfile.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/profile/OAuthProfile.java
@@ -17,6 +17,7 @@ public abstract class OAuthProfile {
     public abstract String getGender();
     public abstract String getName();
     public abstract String getPhoneNumber();
+    public abstract String getProfileImageUrl();
     public abstract String getProvider();
     public abstract String getProviderId();
 

--- a/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/profile/detail/KakaoProfile.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/profile/detail/KakaoProfile.java
@@ -25,6 +25,11 @@ public class KakaoProfile extends OAuthProfile {
     }
 
     @Override
+    public String getProfileImageUrl() {
+        return String.valueOf(getProfile().get("profile_image_url"));
+    }
+
+    @Override
     public String getProvider() {
         return "KAKAO";
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #168 

## 📝작업 내용
- [ ] 로그인 시 응답 Body에 `id`, 필드 추가
- [ ] 소셜 사용자 프로필 URL을 가져오는 로직 추가


## ✅테스트 결과
<img width="732" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/90dd6857-8f6a-4a4f-b793-8fad4253846d">
