### PR TITLE
기여한 펀딩내역 조회 기능 추가

### DIFF
--- a/src/main/java/org/kakaoshare/backend/common/util/EnumValidator.java
+++ b/src/main/java/org/kakaoshare/backend/common/util/EnumValidator.java
@@ -1,5 +1,6 @@
 package org.kakaoshare.backend.common.util;
 
+import com.querydsl.core.util.StringUtils;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
@@ -18,6 +19,10 @@ public class EnumValidator implements ConstraintValidator<EnumValue, String> {
         final Enum<?>[] enumConstants = enumValue.enumClass().getEnumConstants();
         if (enumConstants == null) {
             return false;
+        }
+
+        if (StringUtils.isNullOrEmpty(value) && enumValue.nullable()) {
+            return true;
         }
 
         return Arrays.stream(enumConstants)

--- a/src/main/java/org/kakaoshare/backend/common/util/EnumValue.java
+++ b/src/main/java/org/kakaoshare/backend/common/util/EnumValue.java
@@ -9,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = EnumValidator.class)
-@Target({ElementType.FIELD, ElementType.METHOD})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface EnumValue {
     Class<? extends Enum<?>> enumClass();
@@ -17,4 +17,5 @@ public @interface EnumValue {
     Class<?> [] groups() default {};
     Class<? extends Payload>[] payload() default {};
     boolean ignoreCase() default false;
+    boolean nullable() default false;
 }

--- a/src/main/java/org/kakaoshare/backend/common/util/RepositoryUtils.java
+++ b/src/main/java/org/kakaoshare/backend/common/util/RepositoryUtils.java
@@ -4,19 +4,23 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.ComparableExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.core.types.dsl.EntityPathBase;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.core.types.dsl.SimpleExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import io.jsonwebtoken.lang.Collections;
+import org.kakaoshare.backend.common.vo.Date;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public final class RepositoryUtils {
@@ -46,6 +50,14 @@ public final class RepositoryUtils {
         }
 
         return simpleExpression.eq(target);
+    }
+
+    public static <T extends ComparableExpression<?>> BooleanExpression eqExpression(final StringExpression stringExpression, final String target) {
+        if (target == null) {
+            return null;
+        }
+
+        return stringExpression.eq(target);
     }
 
     public static <T extends Comparable<?>> BooleanExpression eqExpression(final SimpleExpression<T> simpleExpression, final SimpleExpression<T> target) {
@@ -84,6 +96,12 @@ public final class RepositoryUtils {
         }
 
         return simpleExpression.in(items);
+    }
+
+
+    public static BooleanExpression containsExpression(final DateTimePath<LocalDateTime> dateExpression,
+                                                       final Date date) {
+        return dateExpression.between(date.getStartDateTime(), date.getEndDateTime());
     }
 
     public static <T> OrderSpecifier<?>[] createOrderSpecifiers(final EntityPathBase<T> qClass, final Pageable pageable) {

--- a/src/main/java/org/kakaoshare/backend/common/vo/Date.java
+++ b/src/main/java/org/kakaoshare/backend/common/vo/Date.java
@@ -1,0 +1,48 @@
+package org.kakaoshare.backend.common.vo;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+
+@Getter
+public final class Date {
+    private static final int MAX_DATE_PERIOD = 1;
+
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+
+    public Date(final LocalDate startDate, final LocalDate endDate) {
+        validateDateRange(startDate, endDate);
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public LocalDateTime getStartDateTime() {
+        return startDate.atStartOfDay();
+    }
+
+    public LocalDateTime getEndDateTime() {
+        return endDate.atTime(LocalTime.MAX);
+    }
+
+    private void validateDateRange(final LocalDate startDate, final LocalDate endDate) {
+        if (startDate == null && endDate == null) {
+            throw new IllegalArgumentException();
+        }
+
+        if (endDate.isAfter(LocalDate.now())) {
+            throw new IllegalArgumentException();
+        }
+
+        if (endDate.isBefore(startDate)) {
+            throw new IllegalArgumentException();
+        }
+
+        if (ChronoUnit.YEARS.between(endDate, startDate) >= MAX_DATE_PERIOD) {
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -1,17 +1,23 @@
 package org.kakaoshare.backend.domain.funding.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.common.util.EnumValue;
+import org.kakaoshare.backend.common.vo.Date;
 import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
 import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
 import org.kakaoshare.backend.domain.funding.dto.RegisterRequest;
 import org.kakaoshare.backend.domain.funding.dto.RegisterResponse;
 import org.kakaoshare.backend.domain.funding.dto.preview.request.FundingPreviewRequest;
 import org.kakaoshare.backend.domain.funding.dto.preview.response.FundingPreviewResponse;
+import org.kakaoshare.backend.domain.funding.entity.FundingDetailStatus;
 import org.kakaoshare.backend.domain.funding.service.FundingService;
 import org.kakaoshare.backend.jwt.util.LoggedInMember;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,11 +25,27 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.springframework.data.domain.Sort.Direction;
+
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1")
 public class FundingController {
+    private static final int DEFAULT_HISTORY_SIZE = 10;
+    private static final String DEFAULT_HISTORY_SORT_VALUE = "createdAt";
+
     private final FundingService fundingService;
+
+    @GetMapping("/funding")
+    public ResponseEntity<?> lookUp(@LoggedInMember final String providerId,
+                                    @ModelAttribute final Date date,
+                                    @EnumValue(enumClass = FundingDetailStatus.class, ignoreCase = true, nullable = true) final String status,
+                                    @PageableDefault(size = DEFAULT_HISTORY_SIZE, sort = DEFAULT_HISTORY_SORT_VALUE, direction = Direction.DESC) final Pageable pageable
+    ) {
+        return ResponseEntity.ok(
+                fundingService.lookUp(providerId, date, status, pageable)
+        );
+    }
 
     @PostMapping("/funding/{productId}")
     public ResponseEntity<?> registerFunding(@PathVariable Long productId, @LoggedInMember String providerId,
@@ -41,8 +63,8 @@ public class FundingController {
 
     @GetMapping("/members/funding/products")
     public ResponseEntity<?> getMyAllFundingProducts(@LoggedInMember String providerId,
-                                                  @RequestParam(value = "page", required = false, defaultValue = "0") int page,
-                                                  @RequestParam(value = "size", required = false, defaultValue = "4") int size) {
+                                                     @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+                                                     @RequestParam(value = "size", required = false, defaultValue = "4") int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
         FundingSliceResponse response = fundingService.getMyAllFundingProducts(providerId, pageRequest);
         return ResponseEntity.ok(response);

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/ContributedFundingHistoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/ContributedFundingHistoryDto.java
@@ -1,0 +1,15 @@
+package org.kakaoshare.backend.domain.funding.dto.inquiry;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDateTime;
+
+public record ContributedFundingHistoryDto(Long fundingId,
+                                           Long fundingDetailId,
+                                           LocalDateTime attributedAt,
+                                           String creatorName,
+                                           String status) {
+    @QueryProjection
+    public ContributedFundingHistoryDto {
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/ContributedFundingHistoryResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/ContributedFundingHistoryResponse.java
@@ -1,0 +1,10 @@
+package org.kakaoshare.backend.domain.funding.dto.inquiry;
+
+import com.querydsl.core.annotations.QueryProjection;
+import org.kakaoshare.backend.domain.product.dto.ProductDto;
+
+public record ContributedFundingHistoryResponse(ProductDto product, ContributedFundingHistoryDto fundingDetail) {
+    @QueryProjection
+    public ContributedFundingHistoryResponse {
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingDetailRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingDetailRepository.java
@@ -2,6 +2,7 @@ package org.kakaoshare.backend.domain.funding.repository;
 
 import org.kakaoshare.backend.domain.funding.entity.Funding;
 import org.kakaoshare.backend.domain.funding.entity.FundingDetail;
+import org.kakaoshare.backend.domain.funding.repository.query.FundingDetailRepositoryCustom;
 import org.kakaoshare.backend.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 
-public interface FundingDetailRepository extends JpaRepository<FundingDetail, Long> {
+public interface FundingDetailRepository extends JpaRepository<FundingDetail, Long>, FundingDetailRepositoryCustom {
     Optional<FundingDetail> findByFundingAndMember(final Funding funding, final Member member);
 
     @Query("SELECT fd FROM FundingDetail fd " +

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingDetailRepositoryCustom.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingDetailRepositoryCustom.java
@@ -1,0 +1,11 @@
+package org.kakaoshare.backend.domain.funding.repository.query;
+
+import org.kakaoshare.backend.common.vo.Date;
+import org.kakaoshare.backend.domain.funding.dto.inquiry.ContributedFundingHistoryResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FundingDetailRepositoryCustom {
+    Page<ContributedFundingHistoryResponse> findHistoryByProviderIdAndDateAndStatus(final String providerId, final Date date, final String status, final Pageable pageable);
+    Page<ContributedFundingHistoryResponse> findHistoryByProviderIdAndDate(final String providerId, final Date date, final Pageable pageable);
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingDetailRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingDetailRepositoryCustomImpl.java
@@ -1,0 +1,113 @@
+package org.kakaoshare.backend.domain.funding.repository.query;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.common.vo.Date;
+import org.kakaoshare.backend.domain.funding.dto.inquiry.ContributedFundingHistoryResponse;
+import org.kakaoshare.backend.domain.funding.dto.inquiry.QContributedFundingHistoryDto;
+import org.kakaoshare.backend.domain.funding.dto.inquiry.QContributedFundingHistoryResponse;
+import org.kakaoshare.backend.domain.member.entity.QMember;
+import org.kakaoshare.backend.domain.product.dto.QProductDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import static org.kakaoshare.backend.common.util.RepositoryUtils.containsExpression;
+import static org.kakaoshare.backend.common.util.RepositoryUtils.createOrderSpecifiers;
+import static org.kakaoshare.backend.common.util.RepositoryUtils.eqExpression;
+import static org.kakaoshare.backend.common.util.RepositoryUtils.toPage;
+import static org.kakaoshare.backend.domain.funding.entity.QFunding.funding;
+import static org.kakaoshare.backend.domain.funding.entity.QFundingDetail.fundingDetail;
+import static org.kakaoshare.backend.domain.member.entity.QMember.member;
+import static org.kakaoshare.backend.domain.product.entity.QProduct.product;
+
+@RequiredArgsConstructor
+public class FundingDetailRepositoryCustomImpl implements FundingDetailRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ContributedFundingHistoryResponse> findHistoryByProviderIdAndDateAndStatus(final String providerId, final Date date, final String status, final Pageable pageable) {
+        final JPAQuery<Long> countQuery = queryFactory.select(fundingDetail.count())
+                .from(fundingDetail)
+                .innerJoin(fundingDetail.funding, funding)
+                .innerJoin(funding.member, new QMember("creator"))
+                .innerJoin(fundingDetail.member, member)
+                .innerJoin(funding.product, product)
+                .where(
+                        eqExpression(member.providerId, providerId),
+                        eqExpression(fundingDetail.status.stringValue(), status),
+                        containsExpression(fundingDetail.createdAt, date)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        final JPAQuery<ContributedFundingHistoryResponse> contentQuery = queryFactory.select(new QContributedFundingHistoryResponse(getProductDto(), getContributedFundingHistoryDto()))
+                .from(fundingDetail)
+                .innerJoin(fundingDetail.funding, funding)
+                .innerJoin(funding.member, new QMember("creator"))
+                .innerJoin(fundingDetail.member, member)
+                .innerJoin(funding.product, product)
+                .where(
+                        eqExpression(member.providerId, providerId),
+                        eqExpression(fundingDetail.status.stringValue(), status),
+                        containsExpression(fundingDetail.createdAt, date)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(createOrderSpecifiers(fundingDetail, pageable));
+
+        return toPage(pageable, contentQuery, countQuery);
+    }
+
+    @Override
+    public Page<ContributedFundingHistoryResponse> findHistoryByProviderIdAndDate(final String providerId, final Date date, final Pageable pageable) {
+        final JPAQuery<Long> countQuery = queryFactory.select(fundingDetail.count())
+                .from(fundingDetail)
+                .innerJoin(fundingDetail.funding, funding)
+                .innerJoin(funding.member, new QMember("creator"))
+                .innerJoin(fundingDetail.member, member)
+                .innerJoin(funding.product, product)
+                .where(
+                        eqExpression(member.providerId, providerId),
+                        containsExpression(fundingDetail.createdAt, date)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        final JPAQuery<ContributedFundingHistoryResponse> contentQuery = queryFactory.select(new QContributedFundingHistoryResponse(getProductDto(), getContributedFundingHistoryDto()))
+                .from(fundingDetail)
+                .innerJoin(fundingDetail.funding, funding)
+                .innerJoin(funding.member, new QMember("creator"))
+                .innerJoin(fundingDetail.member, member)
+                .innerJoin(funding.product, product)
+                .where(
+                        eqExpression(member.providerId, providerId),
+                        containsExpression(fundingDetail.createdAt, date)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(createOrderSpecifiers(fundingDetail, pageable));
+
+        return toPage(pageable, contentQuery, countQuery);
+    }
+
+    private QProductDto getProductDto() {
+        return new QProductDto(
+                product.productId,
+                product.name,
+                product.photo,
+                product.price,
+                product.brandName
+        );
+    }
+
+    private QContributedFundingHistoryDto getContributedFundingHistoryDto() {
+        return new QContributedFundingHistoryDto(
+                funding.fundingId,
+                fundingDetail.fundingDetailId,
+                fundingDetail.createdAt,
+                member.name,
+                fundingDetail.status.stringValue()
+        );
+    }
+}

--- a/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingServiceTest.java
@@ -1,58 +1,135 @@
-//package org.kakaoshare.backend.domain.funding.service;
-//
-//import static org.junit.jupiter.api.Assertions.assertThrows;
-//import static org.mockito.ArgumentMatchers.any;
-//
-//import java.math.BigDecimal;
-//import java.time.LocalDate;
-//import java.util.Arrays;
-//import java.util.List;
-//import java.util.Optional;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.kakaoshare.backend.domain.brand.entity.Brand;
-//import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
-//import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
-//import org.kakaoshare.backend.domain.funding.dto.RegisterRequest;
-//import org.kakaoshare.backend.domain.funding.dto.RegisterResponse;
-//import org.kakaoshare.backend.domain.funding.entity.Funding;
-//import org.kakaoshare.backend.domain.funding.repository.FundingRepository;
-//import org.kakaoshare.backend.domain.member.entity.Member;
-//import org.kakaoshare.backend.domain.member.repository.MemberRepository;
-//import org.kakaoshare.backend.domain.product.entity.Product;
-//import org.kakaoshare.backend.domain.product.repository.ProductRepository;
-//import org.kakaoshare.backend.fixture.BrandFixture;
-//import org.kakaoshare.backend.fixture.FundingFixture;
-//import org.kakaoshare.backend.fixture.MemberFixture;
-//import org.kakaoshare.backend.fixture.ProductFixture;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.domain.PageRequest;
-//import org.springframework.data.domain.Pageable;
-//import org.springframework.data.domain.Slice;
-//import org.springframework.data.domain.SliceImpl;
-//
-//import static org.mockito.Mockito.*;
-//import static org.mockito.BDDMockito.given;
-//import static org.assertj.core.api.Assertions.assertThat;
-//
-//@ExtendWith(MockitoExtension.class)
-//public class FundingServiceTest {
-//
-//    @InjectMocks
-//    private FundingService fundingService;
-//
-//    @Mock
-//    private ProductRepository productRepository;
-//
-//    @Mock
-//    private MemberRepository memberRepository;
-//
-//    @Mock
-//    private FundingRepository fundingRepository;
-//
+package org.kakaoshare.backend.domain.funding.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kakaoshare.backend.common.dto.PageResponse;
+import org.kakaoshare.backend.common.vo.Date;
+import org.kakaoshare.backend.domain.funding.dto.inquiry.ContributedFundingHistoryDto;
+import org.kakaoshare.backend.domain.funding.dto.inquiry.ContributedFundingHistoryResponse;
+import org.kakaoshare.backend.domain.funding.repository.FundingDetailRepository;
+import org.kakaoshare.backend.domain.funding.repository.FundingRepository;
+import org.kakaoshare.backend.domain.member.entity.Member;
+import org.kakaoshare.backend.domain.member.repository.MemberRepository;
+import org.kakaoshare.backend.domain.product.dto.ProductDto;
+import org.kakaoshare.backend.domain.product.entity.Product;
+import org.kakaoshare.backend.domain.product.repository.ProductRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kakaoshare.backend.domain.funding.entity.FundingDetailStatus.COMPLETE;
+import static org.kakaoshare.backend.domain.funding.entity.FundingDetailStatus.PROGRESS;
+import static org.kakaoshare.backend.fixture.MemberFixture.KAKAO;
+import static org.kakaoshare.backend.fixture.MemberFixture.KIM;
+import static org.kakaoshare.backend.fixture.ProductFixture.CAKE;
+import static org.kakaoshare.backend.fixture.ProductFixture.COFFEE;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+public class FundingServiceTest {
+
+    @InjectMocks
+    private FundingService fundingService;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private FundingRepository fundingRepository;
+
+    @Mock
+    private FundingDetailRepository fundingDetailRepository;
+
+    Member contributor;
+    Member creator;
+
+    @BeforeEach
+    public void setUp() {
+        contributor = KAKAO.생성();
+        creator = KIM.생성();
+    }
+
+    @ParameterizedTest
+    @DisplayName("내가 기여한 펀딩 내역 조회 (상태 필터링 O)")
+    @ValueSource(strings = {"PROGRESS", "COMPLETE", "CANCEL_REFUND"})
+    public void lookUp(final String status) throws Exception {
+        final String providerId = contributor.getProviderId();
+        final Date date = new Date(
+                LocalDate.now().minusMonths(5L),
+                LocalDate.now()
+        );
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdAt"));
+
+        final Product cake = CAKE.생성();
+        final Product coffee = COFFEE.생성();
+
+        final List<ContributedFundingHistoryResponse> content = List.of(
+                new ContributedFundingHistoryResponse(
+                        getProductDto(cake),
+                        getFundingHistoryDto(1L, 1L, LocalDateTime.now().minusDays(20L), creator.getName(), status)
+                ),
+                new ContributedFundingHistoryResponse(
+                        getProductDto(coffee),
+                        getFundingHistoryDto(2L, 2L, LocalDateTime.now().minusDays(20L), creator.getName(), status)
+                )
+        );
+        final Page<?> page = new PageImpl<>(content, pageable, content.size());
+        doReturn(page).when(fundingDetailRepository).findHistoryByProviderIdAndDateAndStatus(providerId, date, status, pageable);
+
+        final PageResponse<?> actual = fundingService.lookUp(providerId, date, status, pageable);
+        final PageResponse<?> expect = PageResponse.from(page);
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expect);
+    }
+
+    @Test
+    @DisplayName("내가 기여한 펀딩 내역 조회 (상태 필터링 X)")
+    public void lookUpWithoutStatus() throws Exception {
+        final String providerId = contributor.getProviderId();
+        final Date date = new Date(
+                LocalDate.now().minusMonths(5L),
+                LocalDate.now()
+        );
+        final String status = null;
+        final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdAt"));
+
+        final Product cake = CAKE.생성();
+        final Product coffee = COFFEE.생성();
+
+        final List<ContributedFundingHistoryResponse> content = List.of(
+                new ContributedFundingHistoryResponse(
+                        getProductDto(cake),
+                        getFundingHistoryDto(1L, 1L, LocalDateTime.now().minusDays(20L), creator.getName(), COMPLETE.name())
+                ),
+                new ContributedFundingHistoryResponse(
+                        getProductDto(coffee),
+                        getFundingHistoryDto(2L, 2L, LocalDateTime.now().minusDays(20L), creator.getName(), PROGRESS.name()
+                        )
+                ));
+        final Page<?> page = new PageImpl<>(content, pageable, content.size());
+        doReturn(page).when(fundingDetailRepository).findHistoryByProviderIdAndDate(providerId, date, pageable);
+
+        final PageResponse<?> actual = fundingService.lookUp(providerId, date, status, pageable);
+        final PageResponse<?> expect = PageResponse.from(page);
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expect);
+    }
+
 //    @Test
 //    @DisplayName("성공적으로 펀딩 아이템 등록")
 //    void registerFundingItem_Success() {
@@ -117,4 +194,21 @@
 //        assertThat(response).isNotNull();
 //        assertThat(response.getFundingItems()).hasSize(fundingList.size());
 //    }
-//}
+
+    public ProductDto getProductDto(final Product product) {
+        return new ProductDto(
+                product.getProductId(),
+                product.getName(),
+                product.getPhoto(),
+                product.getPrice(),
+                product.getBrandName()
+        );
+    }
+
+    public ContributedFundingHistoryDto getFundingHistoryDto(final Long fundingId,
+                                                             final Long fundingDetailId,
+                                                             final LocalDateTime attributedAt,
+                                                             final String creatorName, final String status) {
+        return new ContributedFundingHistoryDto(fundingId, fundingDetailId, attributedAt, creatorName, status);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #178 

## 📝작업 내용
- 기여한 펀딩 내역 조회 기능 추가
  - 날짜 필터링
  - 상태 필터링
- 조회 시 날짜 필터링에 사용될 `Date` VO 객체 추가
  - 날짜 핕러링 시 파라미터 검증 중복 코드가 발생할 것 같아 도입 (자세한 것은 [날짜 필터링에 사용할 VO를 만드는건 어떨까요? ](https://github.com/KakaoFunding/back-end/discussions/179) 참고)

## ✅테스트 결과
### Controller 테스트
- 포스트맨 참고

### Service 테스트
<img width="419" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/ad8d7710-e933-449c-92bb-b90d6ad35328">
