### PR TITLE
주문내역 조회 로직 변경

### DIFF
--- a/src/main/java/org/kakaoshare/backend/common/vo/Date.java
+++ b/src/main/java/org/kakaoshare/backend/common/vo/Date.java
@@ -7,14 +7,11 @@ import lombok.ToString;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 
 @EqualsAndHashCode
 @Getter
 @ToString
 public abstract class Date {
-    private static final int MAX_DATE_PERIOD = 1;
-
     private final LocalDate startDate;
     private final LocalDate endDate;
 
@@ -42,10 +39,6 @@ public abstract class Date {
         }
 
         if (endDate.isBefore(startDate)) {
-            throw new IllegalArgumentException();
-        }
-
-        if (ChronoUnit.YEARS.between(endDate, startDate) >= MAX_DATE_PERIOD) {
             throw new IllegalArgumentException();
         }
     }

--- a/src/main/java/org/kakaoshare/backend/domain/order/controller/OrderController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/order/controller/OrderController.java
@@ -1,22 +1,15 @@
 package org.kakaoshare.backend.domain.order.controller;
 
-import jakarta.validation.constraints.PastOrPresent;
 import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.domain.order.dto.inquiry.OrderHistoryRequest;
 import org.kakaoshare.backend.domain.order.dto.preview.OrderPreviewRequest;
 import org.kakaoshare.backend.domain.order.service.OrderService;
+import org.kakaoshare.backend.jwt.util.LoggedInMember;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -35,10 +28,10 @@ public class OrderController {
     }
 
     @GetMapping
-    public ResponseEntity<?> lookUp(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate startDate,
-                                    @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @PastOrPresent final LocalDate endDate,
+    public ResponseEntity<?> lookUp(@LoggedInMember final String providerId,
+                                    @ModelAttribute final OrderHistoryRequest orderHistoryRequest,
                                     @PageableDefault(size = DEFAULT_ORDER_PAGE_SIZE) final Pageable pageable) {
-        return ResponseEntity.ok(orderService.lookUp(startDate, endDate, pageable));
+        return ResponseEntity.ok(orderService.lookUp(providerId, orderHistoryRequest, pageable));
     }
 
     @GetMapping("/{orderId}")

--- a/src/main/java/org/kakaoshare/backend/domain/order/dto/inquiry/OrderHistoryRequest.java
+++ b/src/main/java/org/kakaoshare/backend/domain/order/dto/inquiry/OrderHistoryRequest.java
@@ -1,0 +1,24 @@
+package org.kakaoshare.backend.domain.order.dto.inquiry;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.kakaoshare.backend.domain.order.vo.OrderHistoryDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+@Data
+@NoArgsConstructor
+public class OrderHistoryRequest {
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate startDate;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate endDate;
+
+    public OrderHistoryDate toDate() {
+        return new OrderHistoryDate(startDate, endDate);
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/order/repository/query/OrderRepositoryCustom.java
+++ b/src/main/java/org/kakaoshare/backend/domain/order/repository/query/OrderRepositoryCustom.java
@@ -2,16 +2,16 @@ package org.kakaoshare.backend.domain.order.repository.query;
 
 import org.kakaoshare.backend.domain.order.dto.inquiry.OrderHistoryDetailDto;
 import org.kakaoshare.backend.domain.order.dto.inquiry.OrderProductDto;
+import org.kakaoshare.backend.domain.order.vo.OrderHistoryDate;
 import org.kakaoshare.backend.domain.rank.dto.RankResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface OrderRepositoryCustom {
     Page<RankResponse> findTopRankedProductsByOrders(LocalDateTime sixMonthsAgo, Pageable pageable);
-    Page<OrderProductDto> findAllOrderProductDtoByDate(final LocalDate startDate, final LocalDate endDate, final Pageable pageable);
+    Page<OrderProductDto> findAllOrderProductDtoByCondition(final String providerId, final OrderHistoryDate date, final Pageable pageable);
     Optional<OrderHistoryDetailDto> findHistoryDetailById(final Long orderId);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/order/service/OrderService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/order/service/OrderService.java
@@ -6,12 +6,14 @@ import org.kakaoshare.backend.domain.option.dto.OptionSummaryRequest;
 import org.kakaoshare.backend.domain.option.repository.OptionDetailRepository;
 import org.kakaoshare.backend.domain.order.dto.inquiry.OrderHistoryDetailDto;
 import org.kakaoshare.backend.domain.order.dto.inquiry.OrderHistoryDetailResponse;
+import org.kakaoshare.backend.domain.order.dto.inquiry.OrderHistoryRequest;
 import org.kakaoshare.backend.domain.order.dto.inquiry.OrderProductDto;
 import org.kakaoshare.backend.domain.order.dto.preview.OrderPreviewRequest;
 import org.kakaoshare.backend.domain.order.dto.preview.OrderPreviewResponse;
 import org.kakaoshare.backend.domain.order.exception.OrderErrorCode;
 import org.kakaoshare.backend.domain.order.exception.OrderException;
 import org.kakaoshare.backend.domain.order.repository.OrderRepository;
+import org.kakaoshare.backend.domain.order.vo.OrderHistoryDate;
 import org.kakaoshare.backend.domain.payment.dto.inquiry.PaymentHistoryDto;
 import org.kakaoshare.backend.domain.payment.exception.PaymentErrorCode;
 import org.kakaoshare.backend.domain.payment.exception.PaymentException;
@@ -58,12 +60,11 @@ public class OrderService {
         return PageResponse.from(page); // TODO: 4/15/24 동일한 상품이 여러 개인 경우를 처리하지 못함
     }
 
-    public PageResponse<?> lookUp(final LocalDate startDate,
-                                  final LocalDate endDate,
+    public PageResponse<?> lookUp(final String providerId,
+                                  final OrderHistoryRequest orderHistoryRequest,
                                   final Pageable pageable) {
-        validateDateRange(startDate, endDate);
-
-        final Page<OrderProductDto> page = orderRepository.findAllOrderProductDtoByDate(startDate, endDate, pageable);
+        final OrderHistoryDate date = orderHistoryRequest.toDate();
+        final Page<OrderProductDto> page = orderRepository.findAllOrderProductDtoByCondition(providerId, date, pageable);
         return PageResponse.from(page);
     }
 

--- a/src/main/java/org/kakaoshare/backend/domain/order/vo/OrderHistoryDate.java
+++ b/src/main/java/org/kakaoshare/backend/domain/order/vo/OrderHistoryDate.java
@@ -1,0 +1,21 @@
+package org.kakaoshare.backend.domain.order.vo;
+
+import org.kakaoshare.backend.common.vo.Date;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+public class OrderHistoryDate extends Date {
+    private static final int MAX_DATE_PERIOD = 1;
+
+    public OrderHistoryDate(final LocalDate startDate, final LocalDate endDate) {
+        super(startDate, endDate);
+        validateDateRange(startDate, endDate);
+    }
+
+    private void validateDateRange(final LocalDate startDate, final LocalDate endDate) {
+        if (ChronoUnit.YEARS.between(endDate, startDate) >= MAX_DATE_PERIOD) {
+            throw new IllegalArgumentException();
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #196 

## 📝작업 내용

 - `OrderService.lookUp()`, `OrderController.lookUp()` 시그니처 변경
   - 별도의 요청 DTO(`OrderHistoryRequest`) 를 사용
   - 파라미터에 `providerId` 추가
 - `OrderRepositoryCustom.findAllOrderProductDtoByDate()` 수정
   - 메서드명을 `findAllOrderProductDtoByCondition` 으로 변경
   - 구현부 메서드 추출
   - `providerId` 를 `where` 문에 추가

## ✅테스트 결과
### Controller 
- 포스트맨 참고

### Service
<img width="565" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/2a5233d2-7703-4874-8ae6-71c3fac21961">
