### PR TITLE
카테고리 ID로 브랜드 조회 응답값을 페이징에서 리스트로 수정

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/brand/controller/BrandController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/brand/controller/BrandController.java
@@ -3,15 +3,10 @@ package org.kakaoshare.backend.domain.brand.controller;
 import lombok.RequiredArgsConstructor;
 import org.kakaoshare.backend.domain.brand.dto.SimpleBrandDto;
 import org.kakaoshare.backend.domain.brand.service.BrandService;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/brands")
@@ -20,10 +15,9 @@ public class BrandController {
     private final BrandService brandService;
     
     @GetMapping
-    public ResponseEntity<?> getSimpleBrandsInfo(@RequestParam("categoryId") final Long categoryId,
-                                                 @PageableDefault(size = 100) final Pageable pageable) {
-        Page<SimpleBrandDto> simpleBrandPage = brandService.getSimpleBrandPage(categoryId, pageable);
-        return ResponseEntity.ok(simpleBrandPage);
+    public ResponseEntity<?> getSimpleBrandsInfo(@RequestParam("categoryId") final Long categoryId) {
+        final List<SimpleBrandDto> simpleBrandDtos = brandService.getSimpleBrandPage(categoryId);
+        return ResponseEntity.ok(simpleBrandDtos);
     }
 
     @GetMapping("/{brandId}")

--- a/src/main/java/org/kakaoshare/backend/domain/brand/repository/query/BrandRepositoryCustom.java
+++ b/src/main/java/org/kakaoshare/backend/domain/brand/repository/query/BrandRepositoryCustom.java
@@ -1,12 +1,11 @@
 package org.kakaoshare.backend.domain.brand.repository.query;
 
 import org.kakaoshare.backend.domain.brand.dto.SimpleBrandDto;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface BrandRepositoryCustom {
-    Page<SimpleBrandDto> findAllSimpleBrandByCategoryId(Long categoryId, Pageable pageable);
+    List<SimpleBrandDto> findAllSimpleBrandByCategoryId(Long categoryId);
     List<SimpleBrandDto> findBySearchConditions(final String keyword, final Pageable pageable);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/brand/service/BrandService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/brand/service/BrandService.java
@@ -1,16 +1,12 @@
 package org.kakaoshare.backend.domain.brand.service;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.kakaoshare.backend.common.util.sort.error.SortErrorCode;
-import org.kakaoshare.backend.common.util.sort.error.exception.NoMorePageException;
 import org.kakaoshare.backend.domain.brand.dto.SimpleBrandDto;
-import org.kakaoshare.backend.domain.brand.entity.Brand;
 import org.kakaoshare.backend.domain.brand.repository.BrandRepository;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -18,12 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class BrandService {
     private final BrandRepository brandRepository;
     
-    public Page<SimpleBrandDto> getSimpleBrandPage(final Long categoryId, final Pageable pageable) {
-        Page<SimpleBrandDto> brandDtos = brandRepository.findAllSimpleBrandByCategoryId(categoryId, pageable);
-        if(brandDtos.isEmpty()){
-            throw new NoMorePageException(SortErrorCode.NO_MORE_PAGE);
-        }
-        return brandDtos;
+    public List<SimpleBrandDto> getSimpleBrandPage(final Long categoryId) {
+        return brandRepository.findAllSimpleBrandByCategoryId(categoryId);
     }
 
     public SimpleBrandDto getBrandNameWithIcon(Long brandId) {

--- a/src/test/java/org/kakaoshare/backend/domain/brand/repository/BrandRepositoryTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/brand/repository/BrandRepositoryTest.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.kakaoshare.backend.common.RepositoryTest;
 import org.kakaoshare.backend.domain.brand.dto.SimpleBrandDto;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,39 +22,22 @@ class BrandRepositoryTest {
     
     @Autowired
     JPAQueryFactory queryFactory;
-    
-    
+
     @Test
-    @DisplayName("자식 카테고리 id를 통해 브랜드 목록을 페이징 조회 가능하다")
+    @DisplayName("자식 카테고리 id를 통해 브랜드 목록 조회")
     void findAllSimpleBrandByChildCategoryId() {
-        // given
-        PageRequest pageRequest = PageRequest.of(0, 30);
-        
-        // when
-        Page<SimpleBrandDto> firstPage = brandRepository.findAllSimpleBrandByCategoryId(CHILD_ID, pageRequest);
-        // then
-        assertThat(firstPage.getContent().size()).isEqualTo(1);
-        
-        assertThat(firstPage.getTotalElements()).isEqualTo(1L);
-        
-        assertThat(firstPage.getContent())
+        List<SimpleBrandDto> simpleBrandDtosByChild = brandRepository.findAllSimpleBrandByCategoryId(CHILD_ID);
+        assertThat(simpleBrandDtosByChild.size()).isEqualTo(1);
+        assertThat(simpleBrandDtosByChild)
                 .isSortedAccordingTo((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(o1.getName(), o2.getName()));
     }
     
     @Test
-    @DisplayName("부모 카테고리 id를 통해 자식 카테고리들이 가진 브랜드 목록을 페이징 조회 가능하다")
+    @DisplayName("부모 카테고리 id를 통해 자식 카테고리들이 가진 브랜드 목록 조회")
     void findAllSimpleBrandByParentCategoryId() {
-        // given
-        PageRequest pageRequest = PageRequest.of(0, 20000);
-        
-        // when
-        Page<SimpleBrandDto> firstPage = brandRepository.findAllSimpleBrandByCategoryId(PARENT_ID, pageRequest);
-        // then
-        assertThat(firstPage.getContent().size()).isEqualTo(50);
-        
-        assertThat(firstPage.getTotalElements()).isEqualTo(50);
-        
-        assertThat(firstPage.getContent())
+        List<SimpleBrandDto> simpleBrandDtosByParent = brandRepository.findAllSimpleBrandByCategoryId(PARENT_ID);
+        assertThat(simpleBrandDtosByParent.size()).isEqualTo(50);
+        assertThat(simpleBrandDtosByParent)
                 .isSortedAccordingTo((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(o1.getName(), o2.getName()));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #200 

## 📝작업 내용
카테고리 id로 브랜드 조회 (`api/v1/brands/{categoryId}`) API 응답값을 페이징 객체에서 `List`로 수정하였습니다.

- `brandController.getSimpleBrandsInfo()` 수정
  - 파라미터에 `Pageable` 제거
- `brandService.getSimpleBrandPage()` 
  - 반환타입을 `Page<?>`에서 `List<?>` 로 수정
- `brandRepository.findAllSimpleBrandByCategoryId()`
  - 반환타입을 `Page<?>`에서 `List<?>` 로 수정
  - 파라미터에 `Pageable` 제거

## ✅테스트 결과
### Controller
- 포스트맨 참고

### Repository
<img width="432" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/12026b2e-0b5b-4d3c-a762-81013b725c61">


## 🙏리뷰 요구사항(선택)
예찬님께서 맡으신 로직을 수정한거라 이상한 부분도 있을겁니다! 피드백주시면 바로 반영하겠습니다!

