### PR TITLE
[HOTFIX]FundingGift의 status 필드에 columnDefinition 속성 추가

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/gift/entity/FundingGift.java
+++ b/src/main/java/org/kakaoshare/backend/domain/gift/entity/FundingGift.java
@@ -22,8 +22,8 @@ public class FundingGift extends BaseTimeEntity {
     private Funding funding;
 
     @Builder.Default
+    @Column(columnDefinition = "VARCHAR(255)", nullable = false)
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private GiftStatus status = NOT_USED;
 
     @Column(nullable = false)


### PR DESCRIPTION
DDL validate 시 enum 타입으로 간주되어 columnDefinition을 사용해 varchar로 명시

## #️⃣연관된 이슈

close #203

## 📝작업 내용
- `FundingGift`의 `status`필드에 `columnDefinition = VARCHAR(255)` 속성 추가