### PR TITLE
[HOTFIX] 선물 결제 승인 오류 수정

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/product/dto/ProductSummaryResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/dto/ProductSummaryResponse.java
@@ -2,11 +2,11 @@ package org.kakaoshare.backend.domain.product.dto;
 
 import org.kakaoshare.backend.domain.product.entity.Product;
 
-public record ProductSummaryResponse(String brandName, String photo, String name) {
+public record ProductSummaryResponse(String brandName, String photo, String name, Long price) {
     public ProductSummaryResponse {
     }
 
     public static ProductSummaryResponse from(final Product product) {
-        return new ProductSummaryResponse(product.getBrandName(), product.getPhoto(), product.getName());
+        return new ProductSummaryResponse(product.getBrandName(), product.getPhoto(), product.getName(), product.getPrice());
     }
 }

--- a/src/test/java/org/kakaoshare/backend/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/payment/service/PaymentServiceTest.java
@@ -208,8 +208,8 @@ class PaymentServiceTest {
         doReturn(null).when(giftRepository).saveAll(any());
         doReturn(null).when(orderRepository).saveAll(any());  // TODO: 3/16/24 saveAll() 에서 new로 다른 객체가 생성되므로 any()로 대체
 
-        final ProductSummaryResponse cakeSummaryResponse = new ProductSummaryResponse(brand.getName(), cake.getName(), coffee.getPhoto());
-        final ProductSummaryResponse coffeeSummaryResponse = new ProductSummaryResponse(brand.getName(), coffee.getName(), coffee.getPhoto());
+        final ProductSummaryResponse cakeSummaryResponse = new ProductSummaryResponse(brand.getName(), cake.getName(), cake.getPhoto(), cake.getPrice());
+        final ProductSummaryResponse coffeeSummaryResponse = new ProductSummaryResponse(brand.getName(), coffee.getName(), coffee.getPhoto(), coffee.getPrice());
         doReturn(cakeSummaryResponse).when(productRepository).findAllProductSummaryById(cake.getProductId());
         doReturn(coffeeSummaryResponse).when(productRepository).findAllProductSummaryById(coffee.getProductId());
 
@@ -270,8 +270,8 @@ class PaymentServiceTest {
         doReturn(null).when(giftRepository).saveAll(any());
         doReturn(null).when(orderRepository).saveAll(any());  // TODO: 3/16/24 saveAll() 에서 new로 다른 객체가 생성되므로 any()로 대체
 
-        final ProductSummaryResponse cakeSummaryResponse = new ProductSummaryResponse(brand.getName(), cake.getName(), cake.getPhoto());
-        final ProductSummaryResponse coffeeSummaryResponse = new ProductSummaryResponse(brand.getName(), coffee.getName(), coffee.getPhoto());
+        final ProductSummaryResponse cakeSummaryResponse = new ProductSummaryResponse(brand.getName(), cake.getName(), cake.getPhoto(), cake.getPrice());
+        final ProductSummaryResponse coffeeSummaryResponse = new ProductSummaryResponse(brand.getName(), coffee.getName(), coffee.getPhoto(), coffee.getPrice());
         doReturn(cakeSummaryResponse).when(productRepository).findAllProductSummaryById(cake.getProductId());
         doReturn(coffeeSummaryResponse).when(productRepository).findAllProductSummaryById(coffee.getProductId());
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #210 

## 📝작업 내용
- `ProductSummaryResponse`에 `price` 필드 추가

### ProductRepository
```java
public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
    @Query("SELECT NEW org.kakaoshare.backend.domain.product.dto.ProductSummaryResponse(p.brandName, p.photo, p.name, p.price) " +
            "FROM Product p " +
            "WHERE p.productId =:productId")
    ProductSummaryResponse findAllProductSummaryById(@Param("productId") final Long productId);
}
```
위 `findAllProductSummaryById()` 메서드에서 `ProductSummaryResponse` 에 적절한 생성자가 없어서 오류가 발생했습니다. 알고보니 4번째 파라미터인 `p.price` 와 매칭되는 필드가 없었습니다. (다른 PR을 올리면서 누락된 것 같습니다.) 
