### PR TITLE
로그인시 생년월일 응답값에 추가

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/authenticate/OAuthLoginMemberResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/authenticate/OAuthLoginMemberResponse.java
@@ -2,11 +2,12 @@ package org.kakaoshare.backend.domain.member.dto.oauth.authenticate;
 
 import org.kakaoshare.backend.domain.member.dto.oauth.profile.OAuthProfile;
 
-public record OAuthLoginMemberResponse(String providerId, String profileUrl, String name) {
+public record OAuthLoginMemberResponse(String providerId, String profileUrl, String birthDate, String name) {
     public static OAuthLoginMemberResponse from(final OAuthProfile oAuthProfile) {
         return new OAuthLoginMemberResponse(
                 oAuthProfile.getProviderId(),
                 oAuthProfile.getProfileImageUrl(),
+                oAuthProfile.getBirthDate(),
                 oAuthProfile.getName()
         );
     }

--- a/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/profile/OAuthProfile.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/profile/OAuthProfile.java
@@ -19,6 +19,7 @@ public abstract class OAuthProfile {
     public abstract String getPhoneNumber();
     public abstract String getProfileImageUrl();
     public abstract String getProvider();
+    public abstract String getBirthDate();
     public abstract String getProviderId();
 
     public Member toEntity() {

--- a/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/profile/detail/KakaoProfile.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/profile/detail/KakaoProfile.java
@@ -35,6 +35,13 @@ public class KakaoProfile extends OAuthProfile {
     }
 
     @Override
+    public String getBirthDate() {
+        final String birthYear = String.valueOf(getAccount().get("birthyear"));
+        final String birthday = String.valueOf(getAccount().get("birthday"));
+        return birthYear + "-" + birthday.substring(0, 2) + "-" + birthday.substring(2);
+    }
+
+    @Override
     public String getProviderId() {
         return String.valueOf(attributes.get("id"));
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #212

## 📝작업 내용
- `OAuthProfile` 에 `getBirthDate()` 추상 메서드 추가
- `KakaoProfile` 에 `getBirthDate()` 메서드 구현
  - 카카오에선 사용자 생일 정보를 생년월일(YYYY), 생일(MMDD) 형식으로 제공하여 이를 적절히 파싱 [참고](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info-response)
- `OAuthLoginMemberResponse` 에 `birtDate` 필드 추가 및 정적 팩토리 메서드 수정

## ✅테스트 결과
### Controller
- 포스트맨 참고

### Service
<img width="391" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/5a339adb-2ba2-49fe-8d90-526a2418de38">
