### PR TITLE
진행중인 펀딩 아이템 조회

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/friend/service/KakaoFriendService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/friend/service/KakaoFriendService.java
@@ -1,17 +1,25 @@
 package org.kakaoshare.backend.domain.friend.service;
 
 import com.querydsl.core.util.StringUtils;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kakaoshare.backend.domain.friend.dto.response.KakaoFriendListResponse;
+import org.kakaoshare.backend.domain.member.dto.oauth.profile.detail.KakaoFriendListDto;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class KakaoFriendService {
+    private static final String FRIENDS_LIST_SERVICE_URL = "https://kapi.kakao.com/v1/api/talk/friends";
+    private final WebClient webClient;
     private final KakaoFriendWebClientService webClientService;
 
     public boolean isFriend(final String socialAccessToken,
@@ -45,5 +53,24 @@ public class KakaoFriendService {
                                             final KakaoFriendListResponse friends) {
         return Arrays.stream(friends.elements())
                 .anyMatch(friend -> String.valueOf(friend.id()).equals(receiverProviderId));
+    }
+
+    public List<KakaoFriendListDto> getFriendsList(String accessToken) {
+        return webClient.get()
+                .uri(FRIENDS_LIST_SERVICE_URL)
+                .headers(headers -> headers.setBearerAuth(accessToken))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .map(response -> (List<Map<String, Object>>) response.get("elements"))
+                .map(elements -> elements.stream()
+                        .map(element -> KakaoFriendListDto.builder()
+                                .id(element.get("id").toString())
+                                .uuid(element.get("uuid").toString())
+                                .favorite((Boolean) element.get("favorite"))
+                                .profileNickname(element.get("profile_nickname").toString())
+                                .profileThumbnailImage(element.get("profile_thumbnail_image").toString())
+                                .build())
+                        .collect(Collectors.toList()))
+                .block();
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -45,7 +45,7 @@ public class FundingController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/friends/active")
+    @GetMapping("/funding/friends/active")
     public ResponseEntity<?> getFriendsActiveFundingItems(@LoggedInMember String providerId,
                                                           @RequestBody FriendFundingItemRequest fundingRequest) {
         List<FundingResponse> activeFundings = fundingService.getFriendsActiveFundingItems(providerId, fundingRequest);

--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -39,7 +39,7 @@ public class FundingController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/members/funding/{fundingId}")
+    @GetMapping("/funding/{fundingId}")
     public ResponseEntity<?> getFundingProgress(@PathVariable Long fundingId, @LoggedInMember String providerId) {
         ProgressResponse response = fundingService.getFundingProgress(fundingId, providerId);
         return ResponseEntity.ok(response);

--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -45,7 +45,7 @@ public class FundingController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/funding/friends/active")
+    @GetMapping("/funding/friends")
     public ResponseEntity<?> getFriendsActiveFundingItems(@LoggedInMember String providerId,
                                                           @RequestBody FriendFundingItemRequest fundingRequest) {
         List<FundingResponse> activeFundings = fundingService.getFriendsActiveFundingItems(providerId, fundingRequest);

--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -8,11 +8,14 @@ import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
 import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
 import org.kakaoshare.backend.domain.funding.dto.RegisterRequest;
 import org.kakaoshare.backend.domain.funding.dto.RegisterResponse;
+import org.kakaoshare.backend.domain.funding.dto.inquiry.FundingContributorResponse;
 import org.kakaoshare.backend.domain.funding.dto.preview.request.FundingPreviewRequest;
 import org.kakaoshare.backend.domain.funding.dto.preview.response.FundingPreviewResponse;
 import org.kakaoshare.backend.domain.funding.entity.FundingStatus;
+import org.kakaoshare.backend.domain.funding.service.FundingDetailService;
 import org.kakaoshare.backend.domain.funding.service.FundingService;
 import org.kakaoshare.backend.jwt.util.LoggedInMember;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 public class FundingController {
     private final FundingService fundingService;
+    private final FundingDetailService fundingDetailService;
     private static final int FUNDING_DEFAULT_SIZE = 20;
 
     @PostMapping("/funding/{productId}")
@@ -64,5 +69,16 @@ public class FundingController {
     public ResponseEntity<?> preview(@RequestBody final FundingPreviewRequest fundingPreviewRequest) {
         final FundingPreviewResponse fundingPreviewResponse = fundingService.preview(fundingPreviewRequest);
         return ResponseEntity.ok(fundingPreviewResponse);
+    }
+
+    @GetMapping("/{fundingId}/contributors")
+    public ResponseEntity<?> getTopContributors(@PathVariable Long fundingId,
+                                                @PageableDefault(size = 5) Pageable pageable,
+                                                @RequestHeader("Authorization") String accessToken) {
+
+        accessToken = accessToken.substring("Bearer ".length()); // Assuming the token is sent as "Bearer [token]"
+        Page<FundingContributorResponse> contributors = fundingDetailService.getTopContributors(fundingId, pageable,
+                accessToken);
+        return ResponseEntity.ok(contributors);
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -1,6 +1,9 @@
 package org.kakaoshare.backend.domain.funding.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.domain.funding.dto.FriendFundingItemRequest;
+import org.kakaoshare.backend.domain.funding.dto.FundingResponse;
 import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
 import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
 import org.kakaoshare.backend.domain.funding.dto.RegisterRequest;
@@ -40,6 +43,13 @@ public class FundingController {
     public ResponseEntity<?> getFundingProgress(@PathVariable Long fundingId, @LoggedInMember String providerId) {
         ProgressResponse response = fundingService.getFundingProgress(fundingId, providerId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/friends/active")
+    public ResponseEntity<?> getFriendsActiveFundingItems(@LoggedInMember String providerId,
+                                                          @RequestBody FriendFundingItemRequest fundingRequest) {
+        List<FundingResponse> activeFundings = fundingService.getFriendsActiveFundingItems(providerId, fundingRequest);
+        return ResponseEntity.ok(activeFundings);
     }
 
     @GetMapping("/members/funding/products")

--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -2,6 +2,7 @@ package org.kakaoshare.backend.domain.funding.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.common.dto.PageResponse;
 import org.kakaoshare.backend.domain.funding.dto.FriendFundingItemRequest;
 import org.kakaoshare.backend.domain.funding.dto.FundingResponse;
 import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
@@ -76,8 +77,8 @@ public class FundingController {
                                                 @PageableDefault(size = 5) Pageable pageable,
                                                 @RequestHeader("Authorization") String accessToken) {
 
-        accessToken = accessToken.substring("Bearer ".length()); // Assuming the token is sent as "Bearer [token]"
-        Page<FundingContributorResponse> contributors = fundingDetailService.getTopContributors(fundingId, pageable,
+        accessToken = accessToken.substring("Bearer ".length());
+        PageResponse<?> contributors = fundingDetailService.getTopContributors(fundingId, pageable,
                 accessToken);
         return ResponseEntity.ok(contributors);
     }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/FriendFundingItemRequest.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/FriendFundingItemRequest.java
@@ -2,10 +2,12 @@ package org.kakaoshare.backend.domain.funding.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.kakaoshare.backend.domain.funding.entity.FundingStatus;
 
 @Getter
 @Builder
 public class FriendFundingItemRequest {
     private String friendsProviderId;
     private String accessToken;
+    private FundingStatus fundingStatus;
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/FriendFundingItemRequest.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/FriendFundingItemRequest.java
@@ -1,0 +1,11 @@
+package org.kakaoshare.backend.domain.funding.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FriendFundingItemRequest {
+    private String friendsProviderId;
+    private String accessToken;
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/FundingResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/FundingResponse.java
@@ -17,13 +17,11 @@ public class FundingResponse {
     private final String brandName;
     private final String productName;
     private final String productImage;
+    private final Long accumulateAmount;
+    private final Long productId;
 
     public static FundingResponse from(Funding funding) {
         Product product = funding.getProduct();
-        String productImage = null;
-        if (product.getProductThumbnails() != null && !product.getProductThumbnails().isEmpty()) {
-            productImage = product.getProductThumbnails().get(0).getThumbnailUrl();
-        }
 
         return FundingResponse.builder()
                 .fundingId(funding.getFundingId())
@@ -32,7 +30,9 @@ public class FundingResponse {
                 .goalAmount(funding.getGoalAmount())
                 .brandName(product.getBrand().getName())
                 .productName(product.getName())
-                .productImage(productImage)
+                .productImage(product.getPhoto())
+                .accumulateAmount(funding.getAccumulateAmount())
+                .productId(product.getProductId())
                 .build();
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/ProgressResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/ProgressResponse.java
@@ -2,9 +2,11 @@ package org.kakaoshare.backend.domain.funding.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.kakaoshare.backend.domain.brand.entity.Brand;
 import org.kakaoshare.backend.domain.funding.entity.Funding;
 
 import java.util.Optional;
+import org.kakaoshare.backend.domain.product.entity.Product;
 
 @Getter
 @Builder
@@ -20,17 +22,26 @@ public class ProgressResponse {
     private final Long remainAmount;
     private final Long goalAmount;
     private final Long accumulateAmount;
+    private final Long productId;
+    private final Long brandId;
+    private final String brandPhoto;
+    private final String productPhoto;
+    private final String brandName;
+    private final String productName;
+
+
 
     public static ProgressResponse from(Funding funding) {
         Long goalAmount = funding.getGoalAmount();
         Long accumulateAmount = funding.getAccumulateAmount();
         double progressRate = Optional.of(goalAmount)
                 .filter(goalAmountValue -> goalAmountValue.compareTo(ZERO) != 0)
-                .map(goalAmountValue ->
-                         divide(accumulateAmount,goalAmountValue, SCALE)
-                                * PERCENT_MULTIPLIER)
+                .map(goalAmountValue -> divide(accumulateAmount, goalAmountValue, SCALE) * PERCENT_MULTIPLIER)
                 .orElse(DEFAULT_PROGRESS_RATE);
-        Long remainAmount = goalAmount-accumulateAmount;
+        Long remainAmount = goalAmount - accumulateAmount;
+
+        Product product = funding.getProduct();
+        Brand brand = product.getBrand();
 
         return ProgressResponse.builder()
                 .fundingId(funding.getFundingId())
@@ -38,6 +49,12 @@ public class ProgressResponse {
                 .remainAmount(remainAmount)
                 .goalAmount(goalAmount)
                 .accumulateAmount(accumulateAmount)
+                .productId(product.getProductId())
+                .brandId(brand.getBrandId())
+                .brandPhoto(brand.getIconPhoto())
+                .productPhoto(product.getPhoto())
+                .brandName(brand.getName())
+                .productName(product.getName())
                 .build();
     }
     

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/ProgressResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/ProgressResponse.java
@@ -30,25 +30,16 @@ public class ProgressResponse {
     private final String productName;
 
 
-
     public static ProgressResponse from(Funding funding) {
-        Long goalAmount = funding.getGoalAmount();
-        Long accumulateAmount = funding.getAccumulateAmount();
-        double progressRate = Optional.of(goalAmount)
-                .filter(goalAmountValue -> goalAmountValue.compareTo(ZERO) != 0)
-                .map(goalAmountValue -> divide(accumulateAmount, goalAmountValue, SCALE) * PERCENT_MULTIPLIER)
-                .orElse(DEFAULT_PROGRESS_RATE);
-        Long remainAmount = goalAmount - accumulateAmount;
-
         Product product = funding.getProduct();
         Brand brand = product.getBrand();
 
         return ProgressResponse.builder()
                 .fundingId(funding.getFundingId())
-                .progressRate(progressRate)
-                .remainAmount(remainAmount)
-                .goalAmount(goalAmount)
-                .accumulateAmount(accumulateAmount)
+                .progressRate(funding.calculateProgressRate())
+                .remainAmount(funding.calculateRemainAmount())
+                .goalAmount(funding.getGoalAmount())
+                .accumulateAmount(funding.getAccumulateAmount())
                 .productId(product.getProductId())
                 .brandId(brand.getBrandId())
                 .brandPhoto(brand.getIconPhoto())
@@ -56,16 +47,5 @@ public class ProgressResponse {
                 .brandName(brand.getName())
                 .productName(product.getName())
                 .build();
-    }
-    
-    private static Double divide(long numerator, long denominator, int scale) {
-        long scaledNumerator = numerator * (long) Math.pow(10, scale + 1);
-        long rawResult = scaledNumerator / denominator;
-        long remainder = rawResult % 10;
-        rawResult /= 10;
-        if (remainder >= 5) {
-            rawResult += 1;
-        }
-        return rawResult / Math.pow(10, scale);
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/FundingContributorResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/FundingContributorResponse.java
@@ -1,0 +1,12 @@
+package org.kakaoshare.backend.domain.funding.dto.inquiry;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FundingContributorResponse {
+    private String profilePhoto;
+    private String profileName;
+    private Long contributedAmount;
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/FundingContributorResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/FundingContributorResponse.java
@@ -2,6 +2,7 @@ package org.kakaoshare.backend.domain.funding.dto.inquiry;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.kakaoshare.backend.domain.friend.dto.response.Friend;
 
 @Getter
 @Builder
@@ -9,4 +10,18 @@ public class FundingContributorResponse {
     private String profilePhoto;
     private String profileName;
     private Long contributedAmount;
+    private Double contributedPercentage;
+
+    public static FundingContributorResponse of(
+            String profilePhoto,
+            String profileName,
+            Long contributedAmount,
+            Double contributionPercentage) {
+        return FundingContributorResponse.builder()
+                .profilePhoto(profilePhoto)
+                .profileName(profileName)
+                .contributedAmount(contributedAmount)
+                .contributedPercentage(contributionPercentage)
+                .build();
+    }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingDetailRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingDetailRepository.java
@@ -4,6 +4,8 @@ import org.kakaoshare.backend.domain.funding.entity.Funding;
 import org.kakaoshare.backend.domain.funding.entity.FundingDetail;
 import org.kakaoshare.backend.domain.funding.repository.query.FundingDetailRepositoryCustom;
 import org.kakaoshare.backend.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +20,8 @@ public interface FundingDetailRepository extends JpaRepository<FundingDetail, Lo
     @Query("SELECT fd FROM FundingDetail fd " +
             "WHERE fd.funding.fundingId =:fundingId")
     List<FundingDetail> findAllByFundingId(@Param("fundingId") final Long fundingId);
+
+    @Query("SELECT fd FROM FundingDetail fd WHERE fd.funding.fundingId = :fundingId ORDER BY fd.amount DESC")
+    Page<FundingDetail> findTopContributorsByFundingId(@Param("fundingId") Long fundingId, Pageable pageable);
+
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingRepository.java
@@ -17,6 +17,7 @@ public interface FundingRepository extends JpaRepository<Funding, Long>, Funding
             "WHERE f.fundingId =:fundingId")
     Optional<FundingProductDto> findAccumulateAmountAndProductIdById(@Param("fundingId") final Long fundingId);
 
-    @Query("SELECT f FROM Funding f WHERE f.member.memberId IN :memberIds AND f.status = 'PROGRESS'")
-    List<Funding> findActiveFundingItemsByMemberIds(List<Long> memberIds);
+    @Query("SELECT f FROM Funding f WHERE f.member.memberId IN :memberIds AND f.status = :status")
+    List<Funding> findActiveFundingItemsByMemberIds(List<Long> memberIds, String status);
+
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingRepository.java
@@ -1,5 +1,6 @@
 package org.kakaoshare.backend.domain.funding.repository;
 
+import java.util.List;
 import org.kakaoshare.backend.domain.funding.dto.preview.request.FundingProductDto;
 import org.kakaoshare.backend.domain.funding.entity.Funding;
 import org.kakaoshare.backend.domain.funding.repository.query.FundingRepositoryCustom;
@@ -15,4 +16,7 @@ public interface FundingRepository extends JpaRepository<Funding, Long>, Funding
             "FROM Funding f " +
             "WHERE f.fundingId =:fundingId")
     Optional<FundingProductDto> findAccumulateAmountAndProductIdById(@Param("fundingId") final Long fundingId);
+
+    @Query("SELECT f FROM Funding f WHERE f.member.memberId IN :memberIds AND f.status = 'PROGRESS'")
+    List<Funding> findActiveFundingItemsByMemberIds(List<Long> memberIds);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingDetailService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingDetailService.java
@@ -1,12 +1,20 @@
 package org.kakaoshare.backend.domain.funding.service;
 
 import com.querydsl.core.util.StringUtils;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.kakaoshare.backend.common.dto.PageResponse;
+import org.kakaoshare.backend.domain.friend.dto.response.Friend;
+import org.kakaoshare.backend.domain.friend.service.KakaoFriendService;
+import org.kakaoshare.backend.domain.funding.dto.inquiry.FundingContributorResponse;
 import org.kakaoshare.backend.domain.funding.dto.inquiry.request.ContributedFundingHistoryRequest;
+import org.kakaoshare.backend.domain.funding.entity.FundingDetail;
 import org.kakaoshare.backend.domain.funding.repository.FundingDetailRepository;
 import org.kakaoshare.backend.domain.funding.vo.FundingHistoryDate;
+import org.kakaoshare.backend.domain.member.dto.oauth.profile.detail.KakaoFriendListDto;
+import org.kakaoshare.backend.domain.member.service.oauth.OAuthWebClientService;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class FundingDetailService {
     private final FundingDetailRepository fundingDetailRepository;
+    private final KakaoFriendService kakaoFriendService;
 
     public PageResponse<?> lookUp(final String providerId,
                                   final ContributedFundingHistoryRequest contributedFundingHistoryRequest,
@@ -32,5 +41,37 @@ public class FundingDetailService {
         }
 
         return fundingDetailRepository.findHistoryByCondition(providerId, date, status, pageable);
+    }
+
+    public Page<FundingContributorResponse> getTopContributors(Long fundingId, Pageable pageable, String accessToken) {
+        Page<FundingDetail> fundingDetails = fundingDetailRepository.findTopContributorsByFundingId(fundingId, pageable);
+
+        List<KakaoFriendListDto> friendsList = kakaoFriendService.getFriendsList(accessToken);
+
+        List<FundingContributorResponse> responses = fundingDetails.stream()
+                .map(detail -> {
+                    KakaoFriendListDto friendProfile = findFriendProfile(detail.getMember().getProviderId(), friendsList);
+                    return FundingContributorResponse.of(
+                            friendProfile.getProfileThumbnailImage(),
+                            friendProfile.getProfileNickname(),
+                            detail.getAmount(),
+                            calculateContributionPercentage(detail)
+                    );
+                }).toList();
+
+        return new PageImpl<>(responses, pageable, fundingDetails.getTotalElements());
+    }
+
+    private KakaoFriendListDto findFriendProfile(String providerId, List<KakaoFriendListDto> friendsList) {
+        return friendsList.stream()
+                .filter(friend -> friend.getId().equals(providerId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No matching friend found for providerId: " + providerId));
+    }
+
+
+
+    private double calculateContributionPercentage(FundingDetail detail) {
+        return 100.0 * detail.getAmount() / detail.getFunding().getGoalAmount();
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingDetailService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingDetailService.java
@@ -43,7 +43,7 @@ public class FundingDetailService {
         return fundingDetailRepository.findHistoryByCondition(providerId, date, status, pageable);
     }
 
-    public Page<FundingContributorResponse> getTopContributors(Long fundingId, Pageable pageable, String accessToken) {
+    public PageResponse<?> getTopContributors(Long fundingId, Pageable pageable, String accessToken) {
         Page<FundingDetail> fundingDetails = fundingDetailRepository.findTopContributorsByFundingId(fundingId, pageable);
 
         List<KakaoFriendListDto> friendsList = kakaoFriendService.getFriendsList(accessToken);
@@ -59,7 +59,8 @@ public class FundingDetailService {
                     );
                 }).toList();
 
-        return new PageImpl<>(responses, pageable, fundingDetails.getTotalElements());
+        Page<FundingContributorResponse> contributorResponses = new PageImpl<>(responses, pageable, fundingDetails.getTotalElements());
+        return PageResponse.from(contributorResponses);
     }
 
     private KakaoFriendListDto findFriendProfile(String providerId, List<KakaoFriendListDto> friendsList) {

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
@@ -95,7 +95,8 @@ public class FundingService {
         List<Member> members = memberRepository.findByProviderIds(providerIds);
         List<Long> memberIds = members.stream().map(Member::getMemberId).toList();
 
-        List<Funding> fundingItems = fundingRepository.findActiveFundingItemsByMemberIds(memberIds);
+        List<Funding> fundingItems = fundingRepository.findActiveFundingItemsByMemberIds(memberIds,
+                friendFundingItemRequest.getFundingStatus().getDescription());
         return fundingItems.stream().map(FundingResponse::from).toList();
     }
 

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
@@ -1,6 +1,7 @@
 package org.kakaoshare.backend.domain.funding.service;
 
 import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.domain.friend.service.KakaoFriendService;
 import org.kakaoshare.backend.domain.funding.dto.FriendFundingItemRequest;
 import org.kakaoshare.backend.domain.funding.dto.FundingResponse;
 import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
@@ -41,8 +42,7 @@ public class FundingService {
     private final FundingRepository fundingRepository;
     private final ProductRepository productRepository;
     private final MemberRepository memberRepository;
-    private final OAuthWebClientService oAuthWebClientService;
-
+    private final KakaoFriendService kakaoFriendService;
 
     @Transactional
     public RegisterResponse registerFundingItem(Long productId, String providerId, RegisterRequest request) {
@@ -128,7 +128,7 @@ public class FundingService {
     }
 
     private List<String> getFriendsProviderIds(FriendFundingItemRequest friendFundingItemRequest) {
-        List<KakaoFriendListDto> friendsList = oAuthWebClientService.getFriendsList(
+        List<KakaoFriendListDto> friendsList = kakaoFriendService.getFriendsList(
                 friendFundingItemRequest.getAccessToken());
         return friendsList.stream()
                 .map(KakaoFriendListDto::getId)
@@ -136,7 +136,7 @@ public class FundingService {
     }
 
     private void validateIsFriend(List<String> providerIds, FriendFundingItemRequest friendFundingItemRequest) {
-        List<KakaoFriendListDto> friends = oAuthWebClientService.getFriendsList(
+        List<KakaoFriendListDto> friends = kakaoFriendService.getFriendsList(
                 friendFundingItemRequest.getAccessToken());
         boolean isFriend = providerIds.stream().anyMatch(providerId ->
                 friends.stream().anyMatch(friend -> friend.getId().equals(providerId)));

--- a/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/profile/detail/KakaoFriendListDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/profile/detail/KakaoFriendListDto.java
@@ -1,0 +1,14 @@
+package org.kakaoshare.backend.domain.member.dto.oauth.profile.detail;
+
+
+import lombok.Builder;
+import lombok.Data;
+@Data
+@Builder
+public final class KakaoFriendListDto {
+    private final String id;
+    private final String uuid;
+    private final boolean favorite;
+    private final String profileNickname;
+    private final String profileThumbnailImage;
+}

--- a/src/main/java/org/kakaoshare/backend/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/exception/MemberErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum MemberErrorCode implements ErrorCode {
-    NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 회원 정보가 없습니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 회원 정보가 없습니다."),
+    NO_SUCH_RELATIONSHIP(HttpStatus.INTERNAL_SERVER_ERROR, "친구가 아닙니다(사용자간 관계가 부적절합니다).");;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/kakaoshare/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/repository/MemberRepository.java
@@ -1,11 +1,15 @@
 package org.kakaoshare.backend.domain.member.repository;
 
+import java.util.List;
 import org.kakaoshare.backend.domain.member.entity.Member;
 import org.kakaoshare.backend.domain.member.repository.query.MemberRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     Optional<Member> findMemberByProviderId(String providerId);
+    @Query("SELECT m FROM Member m WHERE m.providerId IN :providerIds")
+    List<Member> findByProviderIds(List<String> providerIds);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/OAuthWebClientService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/OAuthWebClientService.java
@@ -27,25 +27,6 @@ public class OAuthWebClientService {
                 .block();
     }
 
-    public List<KakaoFriendListDto> getFriendsList(String accessToken) {
-        return webClient.get()
-                .uri(FRIENDS_LIST_SERVICE_URL)
-                .headers(headers -> headers.setBearerAuth(accessToken))
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
-                .map(response -> (List<Map<String, Object>>) response.get("elements"))
-                .map(elements -> elements.stream()
-                        .map(element -> KakaoFriendListDto.builder()
-                                .id(element.get("id").toString())
-                                .uuid(element.get("uuid").toString())
-                                .favorite((Boolean) element.get("favorite"))
-                                .profileNickname(element.get("profile_nickname").toString())
-                                .profileThumbnailImage(element.get("profile_thumbnail_image").toString())
-                                .build())
-                        .collect(Collectors.toList()))
-                .block();
-    }
-
     private String getProfileRequestUri(final ClientRegistration registration) {
         return registration.getProviderDetails()
                 .getUserInfoEndpoint()

--- a/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/OAuthWebClientService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/OAuthWebClientService.java
@@ -1,6 +1,9 @@
 package org.kakaoshare.backend.domain.member.service.oauth;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.domain.member.dto.oauth.profile.detail.KakaoFriendListDto;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.stereotype.Service;
@@ -11,6 +14,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Service
 public class OAuthWebClientService {
+    private static final String FRIENDS_LIST_SERVICE_URL = "https://kapi.kakao.com/v1/api/talk/friends";
     private final WebClient webClient;
 
     public Map<String, Object> getSocialProfile(final ClientRegistration registration,
@@ -20,6 +24,25 @@ public class OAuthWebClientService {
                 .headers(header -> header.setBearerAuth(socialToken))
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+    }
+
+    public List<KakaoFriendListDto> getFriendsList(String accessToken) {
+        return webClient.get()
+                .uri(FRIENDS_LIST_SERVICE_URL)
+                .headers(headers -> headers.setBearerAuth(accessToken))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .map(response -> (List<Map<String, Object>>) response.get("elements"))
+                .map(elements -> elements.stream()
+                        .map(element -> KakaoFriendListDto.builder()
+                                .id(element.get("id").toString())
+                                .uuid(element.get("uuid").toString())
+                                .favorite((Boolean) element.get("favorite"))
+                                .profileNickname(element.get("profile_nickname").toString())
+                                .profileThumbnailImage(element.get("profile_thumbnail_image").toString())
+                                .build())
+                        .collect(Collectors.toList()))
                 .block();
     }
 

--- a/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingServiceTest.java
@@ -1,90 +1,92 @@
-//package org.kakaoshare.backend.domain.funding.service;
-//
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.kakaoshare.backend.domain.funding.repository.FundingRepository;
-//import org.kakaoshare.backend.domain.member.repository.MemberRepository;
-//import org.kakaoshare.backend.domain.product.repository.ProductRepository;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//@ExtendWith(MockitoExtension.class)
-//public class FundingServiceTest {
-//
-//    @InjectMocks
-//    private FundingService fundingService;
-//
-//    @Mock
-//    private ProductRepository productRepository;
-//
-//    @Mock
-//    private MemberRepository memberRepository;
-//
-//    @Mock
-//    private FundingRepository fundingRepository;
-//
-//    @Test
-//    @DisplayName("성공적으로 펀딩 아이템 등록")
-//    void registerFundingItem_Success() {
-//        Long productId = 1L;
-//        String providerId = "provider123";
-//        RegisterRequest request = RegisterRequest.builder()
-//                .goalAmount(new BigDecimal("1000"))
-//                .expiredAt(LocalDate.now().plusDays(30))
-//                .build();
-//
-//        Product product = ProductFixture.TEST_PRODUCT.생성();
-//        Member member = MemberFixture.KAKAO.생성();
-//        Funding funding = FundingFixture.SAMPLE_FUNDING.생성(member, product);
-//
-//        given(productRepository.findById(productId)).willReturn(Optional.of(product));
-//        given(memberRepository.findMemberByProviderId(providerId)).willReturn(Optional.of(member));
-//        given(fundingRepository.findByIdAndMemberId(any(), any())).willReturn(Optional.empty());
-//        given(fundingRepository.save(any(Funding.class))).willReturn(funding);
-//
-//        RegisterResponse response = fundingService.registerFundingItem(productId, providerId, request);
-//
-//        assertThat(response).isNotNull();
-//        assertThat(response.getId()).isEqualTo(funding.getFundingId());
-//    }
-//
-//    @Test
-//    @DisplayName("펀딩 진행 상황 조회 성공")
-//    void getFundingProgress_Success() {
-//        Long fundingId = 1L;
-//        Member member = MemberFixture.KAKAO.생성();
-//        Product product = ProductFixture.TEST_PRODUCT.생성();
-//        Funding funding = FundingFixture.SAMPLE_FUNDING.생성(member, product);
-//
-//        given(memberRepository.findMemberByProviderId(member.getProviderId())).willReturn(Optional.of(member));
-//        given(fundingRepository.findByIdAndMemberId(fundingId, member.getMemberId())).willReturn(Optional.of(funding));
-//
-//        ProgressResponse response = fundingService.getFundingProgress(fundingId, member.getProviderId());
-//
-//        assertThat(response).isNotNull();
-//
-//        verify(memberRepository).findMemberByProviderId(member.getProviderId());
-//        verify(fundingRepository).findByIdAndMemberId(fundingId, member.getMemberId());
-//    }
-//
-//    @Test
-//    @DisplayName("내가 등록한 펀딩아이템 조회 성공")
-//    void getMyAllFundingItems_Success() {
-//        Pageable pageable = PageRequest.of(0, 10);
-//        Member member = MemberFixture.KAKAO.생성();
-//        Brand brand = BrandFixture.BRAND_C.생성();
-//        Product product = ProductFixture.TEST_PRODUCT.생성(brand);
-//        List<Funding> fundingList = Arrays.asList(FundingFixture.SAMPLE_FUNDING.생성(member, product),
-//                FundingFixture.SAMPLE_FUNDING2.생성(member, product));
-//        Slice<Funding> fundingSlice = new SliceImpl<>(fundingList, pageable, false);
-//
-//        when(memberRepository.findMemberByProviderId(member.getProviderId())).thenReturn(Optional.of(member));
-//        when(fundingRepository.findAllByMemberId(member.getMemberId())).thenReturn(fundingList);
-//        when(fundingRepository.findFundingByMemberIdWithSlice(member.getMemberId(), pageable)).thenReturn(fundingSlice);
-//
-//        FundingSliceResponse response = fundingService.getMyAllFundingProducts(member.getProviderId(), pageable);
-//
-//        assertThat(response).isNotNull();
-//        assertThat(response.getFundingItems()).hasSize(fundingList.size());
-//    }
-//}
+package org.kakaoshare.backend.domain.funding.service;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kakaoshare.backend.domain.brand.entity.Brand;
+import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
+import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
+import org.kakaoshare.backend.domain.funding.dto.RegisterRequest;
+import org.kakaoshare.backend.domain.funding.dto.RegisterResponse;
+import org.kakaoshare.backend.domain.funding.entity.Funding;
+import org.kakaoshare.backend.domain.funding.repository.FundingRepository;
+import org.kakaoshare.backend.domain.member.entity.Member;
+import org.kakaoshare.backend.domain.member.repository.MemberRepository;
+import org.kakaoshare.backend.domain.product.entity.Product;
+import org.kakaoshare.backend.domain.product.repository.ProductRepository;
+import org.kakaoshare.backend.fixture.BrandFixture;
+import org.kakaoshare.backend.fixture.FundingFixture;
+import org.kakaoshare.backend.fixture.MemberFixture;
+import org.kakaoshare.backend.fixture.ProductFixture;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+
+@ExtendWith(MockitoExtension.class)
+public class FundingServiceTest {
+
+    @InjectMocks
+    private FundingService fundingService;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private FundingRepository fundingRepository;
+
+    @Test
+    @DisplayName("성공적으로 펀딩 아이템 등록")
+    void registerFundingItem_Success() {
+        Long productId = 1L;
+        String providerId = "provider123";
+        RegisterRequest request = RegisterRequest.builder()
+                .goalAmount(1000L)
+                .expiredAt(LocalDate.now().plusDays(30))
+                .build();
+
+        Product product = ProductFixture.TEST_PRODUCT.생성();
+        Member member = MemberFixture.KAKAO.생성();
+        Funding funding = FundingFixture.SAMPLE_FUNDING.생성(member, product);
+
+        given(productRepository.findById(productId)).willReturn(Optional.of(product));
+        given(memberRepository.findMemberByProviderId(providerId)).willReturn(Optional.of(member));
+        given(fundingRepository.save(any(Funding.class))).willReturn(funding);
+
+        RegisterResponse response = fundingService.registerFundingItem(productId, providerId, request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(funding.getFundingId());
+    }
+
+    @Test
+    @DisplayName("펀딩 진행 상황 조회 성공")
+    void getFundingProgress_Success() {
+        Long fundingId = 1L;
+        Brand brand = BrandFixture.EDIYA.생성(1L);
+        Member member = MemberFixture.KAKAO.생성();
+        Product product = ProductFixture.TEST_PRODUCT.생성(1L,brand);
+        Funding funding = FundingFixture.SAMPLE_FUNDING.생성(member, product);
+
+        given(memberRepository.findMemberByProviderId(member.getProviderId())).willReturn(Optional.of(member));
+        given(fundingRepository.findByIdAndMemberId(fundingId, member.getMemberId())).willReturn(Optional.of(funding));
+
+        ProgressResponse response = fundingService.getFundingProgress(fundingId, member.getProviderId());
+
+        assertThat(response).isNotNull();
+
+        verify(memberRepository).findMemberByProviderId(member.getProviderId());
+        verify(fundingRepository).findByIdAndMemberId(fundingId, member.getMemberId());
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #216 

## 📝작업 내용

- 펀딩 id를 기준으로 펀딩아이템 조회 기능 구현
- 친구들의 펀딩아이템 조회 기능 구현
- 펀딩 기여한 친구들의 랭킹구현은 아직 안됬습니다. 알바다녀와서 새벽에 작업하겠습니다.(기간이 얼마남지 않아 수정할 부분을 미리 지적받고 싶어 pr올립니다.)


## ✅테스트 결과

<img width="310" alt="image" src="https://github.com/KakaoFunding/back-end/assets/93575221/acc95c18-98a7-4bbc-ada6-702cf97a1d80">

내 진행중인 펀딩아이템 조회는 잘 되는것 같습니다. 하지만 이전 예찬님의 친구들의 위시목록 조회도 외부 api의 덕에 테스트 구현이 힘들었던걸로 기억하는데 mock을 처리해서 테스트를 할까 고민중에 있는데 그부분도 mocking을 하는데 시간이 오래걸릴것같습니다. 

## 🙏리뷰 요구사항(선택)

친구들의 펀딩아이템 조회를 하고싶어도 프로젝트 developer에 제가 안들어가있어서 테스트를 해볼수가 없네요.. 이부분 저번에도 부탁드린것 같긴한데 확인 부탁드립니다.

