### PR TITLE
[HOTFIX] 기여한 펀딩내역 조회 응답값에 기여 금액 추가

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/ContributedFundingHistoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/ContributedFundingHistoryDto.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 public record ContributedFundingHistoryDto(Long fundingId,
                                            Long fundingDetailId,
+                                           Long attributeAmount,
                                            LocalDateTime attributedAt,
                                            String creatorName,
                                            String status) {

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/ContributedFundingHistoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/ContributedFundingHistoryDto.java
@@ -6,8 +6,8 @@ import java.time.LocalDateTime;
 
 public record ContributedFundingHistoryDto(Long fundingId,
                                            Long fundingDetailId,
-                                           Long attributeAmount,
-                                           LocalDateTime attributedAt,
+                                           Long contributedAmount,
+                                           LocalDateTime contributedAt,
                                            String creatorName,
                                            String status) {
     @QueryProjection

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingDetailRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingDetailRepositoryCustomImpl.java
@@ -108,6 +108,7 @@ public class FundingDetailRepositoryCustomImpl implements FundingDetailRepositor
         return new QContributedFundingHistoryDto(
                 funding.fundingId,
                 fundingDetail.fundingDetailId,
+                fundingDetail.amount,
                 fundingDetail.createdAt,
                 member.name,
                 fundingDetail.status.stringValue()

--- a/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingDetailServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingDetailServiceTest.java
@@ -130,8 +130,8 @@ public class FundingDetailServiceTest {
 
     private ContributedFundingHistoryDto getFundingHistoryDto(final Long fundingId,
                                                              final Long fundingDetailId,
-                                                             final LocalDateTime attributedAt,
+                                                             final LocalDateTime contributedAt,
                                                              final String creatorName, final String status) {
-        return new ContributedFundingHistoryDto(fundingId, fundingDetailId, 1000L, attributedAt, creatorName, status);
+        return new ContributedFundingHistoryDto(fundingId, fundingDetailId, 1000L, contributedAt, creatorName, status);
     }
 }

--- a/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingDetailServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingDetailServiceTest.java
@@ -132,6 +132,6 @@ public class FundingDetailServiceTest {
                                                              final Long fundingDetailId,
                                                              final LocalDateTime attributedAt,
                                                              final String creatorName, final String status) {
-        return new ContributedFundingHistoryDto(fundingId, fundingDetailId, attributedAt, creatorName, status);
+        return new ContributedFundingHistoryDto(fundingId, fundingDetailId, 1000L, attributedAt, creatorName, status);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #221 

## 📝작업 내용
- `ContributedFundingHistoryDto` 에 `attributeAmount` 필드 추가
  - 이에 영향받는 `FundingDetailServiceTest`, `FundingDetailRepositoryCustomImpl` 수정
## ✅테스트 결과
<img width="441" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/b38b0d2e-4905-4554-99ec-da2fc891fda5">
