### PR TITLE
[fix] 등록했던 펀딩아이템 조회 페이지 응답객체 타입 수정

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -3,11 +3,9 @@ package org.kakaoshare.backend.domain.funding.controller;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.kakaoshare.backend.common.dto.PageResponse;
-<<<<<<< refactor/myFunding
-=======
+
 import org.kakaoshare.backend.domain.funding.dto.FriendFundingItemRequest;
 import org.kakaoshare.backend.domain.funding.dto.FundingResponse;
->>>>>>> develop
 import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
 import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
 import org.kakaoshare.backend.domain.funding.dto.RegisterRequest;

--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -1,6 +1,7 @@
 package org.kakaoshare.backend.domain.funding.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.common.dto.PageResponse;
 import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
 import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
 import org.kakaoshare.backend.domain.funding.dto.RegisterRequest;
@@ -46,7 +47,7 @@ public class FundingController {
     public ResponseEntity<?> getMyAllFundingProducts(@LoggedInMember String providerId,
                                                      @RequestParam(name = "status", required = false, defaultValue = "PROGRESS") FundingStatus status,
                                                      @PageableDefault(size = FUNDING_DEFAULT_SIZE) final Pageable pageable) {
-        FundingSliceResponse response = fundingService.getMyFilteredFundingProducts(providerId, status, pageable);
+        PageResponse<?> response = fundingService.getMyFilteredFundingProducts(providerId, status, pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingRepositoryCustom.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingRepositoryCustom.java
@@ -16,5 +16,5 @@ public interface FundingRepositoryCustom {
 
     List<Funding> findAllByMemberId(Long memberId);
 
-    Page<Funding> findFundingByMemberIdAndStatusWithPage(Long memberId, FundingStatus status, Pageable pageable);
+    Page<FundingResponse> findFundingByMemberIdAndStatusWithPage(Long memberId, FundingStatus status, Pageable pageable);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package org.kakaoshare.backend.domain.funding.repository.query;
 import static org.kakaoshare.backend.common.util.sort.SortUtil.MOST_RECENT;
 
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -18,6 +19,7 @@ import org.kakaoshare.backend.domain.funding.dto.FundingResponse;
 import org.kakaoshare.backend.domain.funding.entity.Funding;
 import org.kakaoshare.backend.domain.funding.entity.FundingStatus;
 import org.kakaoshare.backend.domain.funding.entity.QFunding;
+import org.kakaoshare.backend.domain.product.entity.QProduct;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -64,10 +66,20 @@ public class FundingRepositoryCustomImpl implements FundingRepositoryCustom, Sor
     }
 
     @Override
-    public Page<Funding> findFundingByMemberIdAndStatusWithPage(Long memberId, FundingStatus status, Pageable pageable) {
-
-        JPAQuery<Funding> contentQuery = queryFactory
-                .selectFrom(QFunding.funding)
+    public Page<FundingResponse> findFundingByMemberIdAndStatusWithPage(Long memberId, FundingStatus status, Pageable pageable) {
+        JPAQuery<FundingResponse> contentQuery = queryFactory
+                .select(Projections.constructor(
+                        FundingResponse.class,
+                        QFunding.funding.fundingId,
+                        QFunding.funding.status.stringValue(),
+                        QFunding.funding.expiredAt,
+                        QFunding.funding.goalAmount,
+                        QFunding.funding.product.brandName,
+                        QFunding.funding.product.name,
+                        QFunding.funding.product.photo
+                ))
+                .from(QFunding.funding)
+                .leftJoin(QFunding.funding.product).on(QFunding.funding.product.productId.eq(QProduct.product.productId))
                 .where(QFunding.funding.member.memberId.eq(memberId)
                         .and(QFunding.funding.status.eq(status)))
                 .orderBy(SortUtil.from(pageable))
@@ -82,6 +94,7 @@ public class FundingRepositoryCustomImpl implements FundingRepositoryCustom, Sor
 
         return RepositoryUtils.toPage(pageable, contentQuery, countQuery);
     }
+
 
     @Override
     public OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
@@ -67,7 +67,7 @@ public class FundingService {
     public PageResponse<?> getMyFilteredFundingProducts(String providerId, FundingStatus status,
                                                      Pageable pageable) {
         Member member = findMemberByProviderId(providerId);
-        Page<Funding> fundingResponses = fundingRepository.findFundingByMemberIdAndStatusWithPage(
+        Page<FundingResponse> fundingResponses = fundingRepository.findFundingByMemberIdAndStatusWithPage(
                 member.getMemberId(), status, pageable);
 
 

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
@@ -1,6 +1,7 @@
 package org.kakaoshare.backend.domain.funding.service;
 
 import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.common.dto.PageResponse;
 import org.kakaoshare.backend.domain.funding.dto.FundingResponse;
 import org.kakaoshare.backend.domain.funding.dto.FundingSliceResponse;
 import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
@@ -21,6 +22,7 @@ import org.kakaoshare.backend.domain.product.entity.Product;
 import org.kakaoshare.backend.domain.product.exception.ProductErrorCode;
 import org.kakaoshare.backend.domain.product.exception.ProductException;
 import org.kakaoshare.backend.domain.product.repository.ProductRepository;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -62,23 +64,14 @@ public class FundingService {
         return ProgressResponse.from(funding);
     }
 
-    public FundingSliceResponse getMyFilteredFundingProducts(String providerId, FundingStatus status,
-                                                             Pageable pageable) {
+    public PageResponse<?> getMyFilteredFundingProducts(String providerId, FundingStatus status,
+                                                     Pageable pageable) {
         Member member = findMemberByProviderId(providerId);
-        Slice<Funding> allFundingSlices = fundingRepository.findFundingByMemberIdAndStatusWithPage(
+        Page<Funding> fundingResponses = fundingRepository.findFundingByMemberIdAndStatusWithPage(
                 member.getMemberId(), status, pageable);
-        List<FundingResponse> fundingResponses = allFundingSlices
-                .getContent()
-                .stream()
-                .map(FundingResponse::from)
-                .toList();
 
-        return FundingSliceResponse.of(
-                fundingResponses,
-                allFundingSlices.getNumberOfElements(),
-                allFundingSlices.getPageable().getPageNumber(),
-                allFundingSlices.isLast()
-        );
+
+        return PageResponse.from(fundingResponses);
     }
 
 


### PR DESCRIPTION
## 📝작업 내용

- 커스텀된 응답 페이지로 반환 해주지 않아 반환타입이 다른점 수정
