### PR TITLE
[HOTFIX] 검색 시 브랜드 중복 데이터 조회 문제 해결

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/brand/repository/query/BrandRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/brand/repository/query/BrandRepositoryCustomImpl.java
@@ -51,8 +51,9 @@ public class BrandRepositoryCustomImpl implements BrandRepositoryCustom, Sortabl
     public List<SimpleBrandDto> findBySearchConditions(final String keyword, final Pageable pageable) {
         return queryFactory.select(getSimpleBrandDto())
                 .from(brand)
-                .leftJoin(product).on(product.brand.eq(brand))
+                .innerJoin(product).on(product.brand.eq(brand))
                 .where(containsExpression(product.name, keyword))
+                .groupBy(brand.brandId)
                 .orderBy(createOrderSpecifiers(brand, pageable))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())


### PR DESCRIPTION
## #️⃣연관된 이슈

close #232 

## 📝작업 내용
- `BrandRepositoryCustomImpl.findBySearchConditions()` 메서드 수정
  - `brand`와 `product` 조인을 `leftJoin()`에서 `innerJoin`()으로 수정
  - `groupBy(brandId)`를 통해 중복 데이터 제거

Brand(1)에서 Product(N)을 `LEFT JOIN` 후 `GROUP BY`를 하지 않아 발생한 문제였습니다. 
따라서, `GROUP BY` 절을 추가하여 중복 데이터를 제거했습니다.

추가로, 상품을 가지지 않는 브랜드를 고려하여 `LEFT JOIN`을 `INNER JOIN`으로 수정하였습니다.


## ✅테스트 결과

### Controller
<img width="854" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/41fb033b-d468-4b81-aac6-fa2e402a27c9">


### 테스트 SQL
```sql
SELECT b.brand_id, b.name, b.icon_photo FROM brand b
INNER JOIN product p on b.brand_id = p.brand_id
WHERE p.name LIKE '%커피%'
GROUP BY b.brand_id;
```
<img width="732" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/6251358b-b057-4a08-b6cc-9115a5f38d68">

- 중복 데이터 (커피스미스)가 제거됨
