### PR TITLE
소셜 로그아웃 로직 추가 및 기존 OAuthWebClientService 계층화

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/member/controller/OAuthController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/controller/OAuthController.java
@@ -5,6 +5,7 @@ import org.kakaoshare.backend.domain.member.dto.oauth.authenticate.OAuthLoginReq
 import org.kakaoshare.backend.domain.member.dto.oauth.authenticate.OAuthLoginResponse;
 import org.kakaoshare.backend.domain.member.dto.oauth.issue.OAuthReissueRequest;
 import org.kakaoshare.backend.domain.member.dto.oauth.logout.OAuthLogoutRequest;
+import org.kakaoshare.backend.domain.member.dto.oauth.logout.OAuthSocialLogoutRequest;
 import org.kakaoshare.backend.domain.member.service.oauth.OAuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +26,13 @@ public class OAuthController {
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@RequestBody final OAuthLogoutRequest oAuthLogoutRequest) {
         oAuthService.logout(oAuthLogoutRequest);
+        return ResponseEntity.noContent()
+                .build();
+    }
+
+    @PostMapping("/social/logout")
+    public ResponseEntity<Void> socialLogout(@RequestBody final OAuthSocialLogoutRequest oAuthSocialLogoutRequest) {
+        oAuthService.socialLogout(oAuthSocialLogoutRequest);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/logout/OAuthSocialLogoutRequest.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/logout/OAuthSocialLogoutRequest.java
@@ -1,0 +1,4 @@
+package org.kakaoshare.backend.domain.member.dto.oauth.logout;
+
+public record OAuthSocialLogoutRequest(String provider, String providerId, String socialAccessToken) {
+}

--- a/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/logout/detail/kakao/request/KakaoLogoutRequest.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/dto/oauth/logout/detail/kakao/request/KakaoLogoutRequest.java
@@ -1,0 +1,4 @@
+package org.kakaoshare.backend.domain.member.dto.oauth.logout.detail.kakao.request;
+
+public record KakaoLogoutRequest(String target_id_type, Long target_id) {
+}

--- a/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/OAuthService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/OAuthService.java
@@ -6,6 +6,7 @@ import org.kakaoshare.backend.domain.member.dto.oauth.authenticate.OAuthLoginRes
 import org.kakaoshare.backend.domain.member.dto.oauth.issue.OAuthReissueRequest;
 import org.kakaoshare.backend.domain.member.dto.oauth.issue.OAuthReissueResponse;
 import org.kakaoshare.backend.domain.member.dto.oauth.logout.OAuthLogoutRequest;
+import org.kakaoshare.backend.domain.member.dto.oauth.logout.OAuthSocialLogoutRequest;
 import org.kakaoshare.backend.domain.member.dto.oauth.profile.OAuthProfile;
 import org.kakaoshare.backend.domain.member.dto.oauth.profile.OAuthProfileFactory;
 import org.kakaoshare.backend.domain.member.entity.MemberDetails;
@@ -54,6 +55,12 @@ public class OAuthService {
         final String refreshTokenValue = oAuthLogoutRequest.refreshToken();
         final RefreshToken refreshToken = findRefreshTokenByValue(refreshTokenValue);
         refreshTokenRepository.delete(refreshToken);
+    }
+
+    public void socialLogout(final OAuthSocialLogoutRequest oAuthSocialLogoutRequest) {
+        final String provider = oAuthSocialLogoutRequest.provider();
+        final ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(provider);
+        webClientService.expireToken(registration, oAuthSocialLogoutRequest);
     }
 
     @Transactional

--- a/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/OAuthWebClientService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/OAuthWebClientService.java
@@ -1,31 +1,12 @@
 package org.kakaoshare.backend.domain.member.service.oauth;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.core.ParameterizedTypeReference;
+import org.kakaoshare.backend.domain.member.dto.oauth.logout.OAuthSocialLogoutRequest;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.Map;
 
-@RequiredArgsConstructor
-@Service
-public class OAuthWebClientService {
-    private final WebClient webClient;
+public interface OAuthWebClientService {
+    Map<String, Object> getSocialProfile(final ClientRegistration registration, final String socialToken);
 
-    public Map<String, Object> getSocialProfile(final ClientRegistration registration,
-                                                final String socialToken) {
-        return webClient.get()
-                .uri(getProfileRequestUri(registration))
-                .headers(header -> header.setBearerAuth(socialToken))
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
-                .block();
-    }
-
-    private String getProfileRequestUri(final ClientRegistration registration) {
-        return registration.getProviderDetails()
-                .getUserInfoEndpoint()
-                .getUri();
-    }
+    void expireToken(final ClientRegistration registration, final OAuthSocialLogoutRequest oAuthSocialLogoutRequest);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/detail/kakao/KakaoOAuthRequestProvider.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/detail/kakao/KakaoOAuthRequestProvider.java
@@ -1,0 +1,15 @@
+package org.kakaoshare.backend.domain.member.service.oauth.detail.kakao;
+
+import lombok.RequiredArgsConstructor;
+import org.kakaoshare.backend.domain.member.dto.oauth.logout.detail.kakao.request.KakaoLogoutRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthRequestProvider {
+    private static final String TARGET_ID_TYPE = "user_id"; // TODO: 5/26/24 회원번호 종류, user_id로 고정 (https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#logout-request-admin-key-body)
+
+    public KakaoLogoutRequest createKakaoLogoutRequest(final String providerId) {
+        return new KakaoLogoutRequest(TARGET_ID_TYPE, Long.parseLong(providerId));
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/detail/kakao/KakaoOAuthService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/detail/kakao/KakaoOAuthService.java
@@ -1,0 +1,59 @@
+package org.kakaoshare.backend.domain.member.service.oauth.detail.kakao;
+
+import org.kakaoshare.backend.domain.member.dto.oauth.logout.OAuthSocialLogoutRequest;
+import org.kakaoshare.backend.domain.member.dto.oauth.logout.detail.kakao.request.KakaoLogoutRequest;
+import org.kakaoshare.backend.domain.member.service.oauth.OAuthWebClientService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Service
+public class KakaoOAuthService implements OAuthWebClientService {
+    private final KakaoOAuthRequestProvider kakaoOAuthRequestProvider;
+    private final String logoutRequestUrl;
+    private final WebClient webClient;
+
+    public KakaoOAuthService(final KakaoOAuthRequestProvider kakaoOAuthRequestProvider,
+                             @Value("${spring.security.oauth2.client.other.kakao.logout-url}") final String logoutRequestUrl,
+                             final WebClient webClient) {
+        this.kakaoOAuthRequestProvider = kakaoOAuthRequestProvider;
+        this.logoutRequestUrl = logoutRequestUrl;
+        this.webClient = webClient;
+    }
+
+    @Override
+    public Map<String, Object> getSocialProfile(final ClientRegistration registration,
+                                                final String socialToken) {
+        return webClient.get()
+                .uri(getProfileRequestUri(registration))
+                .headers(header -> header.setBearerAuth(socialToken))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+    }
+
+    @Override
+    public void expireToken(final ClientRegistration registration,
+                            final OAuthSocialLogoutRequest oAuthSocialLogoutRequest) {
+        final String socialAccessTokenToken = oAuthSocialLogoutRequest.socialAccessToken();
+        final String providerId = oAuthSocialLogoutRequest.providerId();
+        final KakaoLogoutRequest kakaoLogoutRequest = kakaoOAuthRequestProvider.createKakaoLogoutRequest(providerId);
+        webClient.post()
+                .uri(logoutRequestUrl)
+                .headers(header -> header.setBearerAuth(socialAccessTokenToken))
+                .bodyValue(kakaoLogoutRequest)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+    }
+
+    private String getProfileRequestUri(final ClientRegistration registration) {
+        return registration.getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUri();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -49,6 +49,10 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+        other:
+          kakao:
+            logout-url: https://kapi.kakao.com/v1/user/logout
+
 security:
   token:
     access:


### PR DESCRIPTION
## #️⃣연관된 이슈

close #236

## 📝작업 내용
기존 로그아웃 시 서버에서 발급한 토큰만 만료가되고 소셜 토큰은 만료되지 않아 악용될 가능성이 있다고 판단했습니다. 따라서, 사용자가 로그아웃 시 소셜 토큰도 만료하는 로직을 추가하였습니다.

이 API는 사용자가 로그아웃을 요청할 때 기존 로그아웃 API(`api/v1/oauth/logout`)와 함께 호출됩니다. 사용자 로그아웃 과정은 아래와 같습니다.

1. 소셜 토큰 만료
2. 서버 토큰 만료

- `OAuthWebClientService` 계층화
  - `OAuthWebClientService`를 인터페이스로 수정
  - `KakaoOAuthService` 구현체 추가
- `OAuthWebClientService.expireToken()` 메서드 추가
- `KakaoOAuthRequestProvider` 클래스 추가
  - 로그아웃 시 필요한 요청값을 만드는 클래스
- `application-dev.yml` 에 카카오 토큰 만료 URL 속성 추가
- `OAuthService`, `OAuthController` 에 `socialLogout()` 메서드 추가

## ✅테스트 결과
### Controller
포스트맨 참고

### Service
<img width="576" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/1483c7bb-984c-4708-9e97-a434ee94deb3">