### PR TITLE
위시 삭제가 DB에 반영되지 않는 문제 해결

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/wish/entity/Wish.java
+++ b/src/main/java/org/kakaoshare/backend/domain/wish/entity/Wish.java
@@ -1,21 +1,7 @@
 package org.kakaoshare.backend.domain.wish.entity;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import org.kakaoshare.backend.domain.base.entity.BaseTimeEntity;
 import org.kakaoshare.backend.domain.member.entity.Member;
 import org.kakaoshare.backend.domain.product.dto.WishType;
@@ -43,7 +29,7 @@ public class Wish extends BaseTimeEntity {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
     
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
     

--- a/src/main/java/org/kakaoshare/backend/domain/wish/repository/WishRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/wish/repository/WishRepository.java
@@ -1,5 +1,7 @@
 package org.kakaoshare.backend.domain.wish.repository;
 
+import org.kakaoshare.backend.domain.member.entity.Member;
+import org.kakaoshare.backend.domain.product.entity.Product;
 import org.kakaoshare.backend.domain.wish.entity.Wish;
 import org.kakaoshare.backend.domain.wish.repository.query.WishRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +11,6 @@ import java.util.List;
 
 public interface WishRepository extends JpaRepository<Wish, Long> , WishRepositoryCustom {
     List<Wish> findByMember_ProviderId(final String providerId);
+
+    void deleteByMemberAndProduct(final Member member, final Product product);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/wish/service/WishService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/wish/service/WishService.java
@@ -8,6 +8,7 @@ import org.kakaoshare.backend.domain.member.exception.MemberException;
 import org.kakaoshare.backend.domain.member.repository.MemberRepository;
 import org.kakaoshare.backend.domain.product.dto.WishCancelEvent;
 import org.kakaoshare.backend.domain.product.dto.WishEvent;
+import org.kakaoshare.backend.domain.product.entity.Product;
 import org.kakaoshare.backend.domain.wish.dto.WishDetail;
 import org.kakaoshare.backend.domain.wish.dto.WishReservationEvent;
 import org.kakaoshare.backend.domain.wish.entity.Wish;
@@ -70,11 +71,11 @@ public class WishService {
             notRecoverable = MemberException.class
     )
     public void handleWishCancel(WishCancelEvent event) {
-        Member member = getMember(event.getProviderId());
-        Wish wish = createWish(event, member);
-        
+        final Member member = getMember(event.getProviderId());
+        final Product product = event.getProduct();
+
         try {
-            wishRepository.delete(wish);
+            wishRepository.deleteByMemberAndProduct(member, product);
         } catch (RuntimeException e) {
             throw new WishException(WishErrorCode.REMOVING_FAILED);
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #243 

## 📝작업 내용
- `WishService.handleWishCancel()` 수정
  - 이전 위시 삭제 로직은 DB에 저장되있는 위시 내역을 삭제하지 않고 삭제하려는 `Wish` 엔티티와 동일한 필드를 갖는 새로운 `Wish` 엔티티를 만들고 이를 삭제하는 방식이였습니다. (`createWish()` 호출 후 이를 삭제)
  - `WishRepository.deleteByMemberAndProduct()` 를 추가하여 현재 삭제하려고 하는 위시 내역을 실제 DB에서 삭제하도록 수정했습니다.
- `Wish` 엔티티 `Member` 필드 Cascade 속성 삭제


## ✅테스트 결과
### Controller
- 포스트맨 참고

### Service
<img width="437" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/104a1227-cb7f-413b-a245-a672d83f59b0">