### PR TITLE
[HOTFIX]날짜 필터링 검증 버그 해결

### DIFF
--- a/src/main/java/org/kakaoshare/backend/common/vo/Date.java
+++ b/src/main/java/org/kakaoshare/backend/common/vo/Date.java
@@ -34,7 +34,7 @@ public abstract class Date {
             throw new IllegalArgumentException();
         }
 
-        if (endDate.isAfter(LocalDate.now())) {
+        if (!endDate.equals(LocalDate.now()) && endDate.isAfter(LocalDate.now())) {
             throw new IllegalArgumentException();
         }
 

--- a/src/main/java/org/kakaoshare/backend/common/vo/Date.java
+++ b/src/main/java/org/kakaoshare/backend/common/vo/Date.java
@@ -30,7 +30,7 @@ public abstract class Date {
     }
 
     private void validateDateRange(final LocalDate startDate, final LocalDate endDate) {
-        if (startDate == null && endDate == null) {
+        if (startDate == null || endDate == null) {
             throw new IllegalArgumentException();
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #254 

## 📝작업 내용
- `Date` VO의 `endDate`가 `LocalDate.now()` 보다 이후인 경우만 검증하도록 수정
- `startDate`, `endDate` 둘 중 하나라도 `null` 이면 예외를 발생시키도록 수정
  - 현재는 두 개 모두 `null`이여야 예외가 발생하도록 구현되있음

`LocalDate.isAfter()`가 같은날인 경우도 `false`를 반환하여 발생한 버그를 해결하였습니다.
