### PR TITLE
[FEAT, REFACTOR] Date VO 예외 핸들링 추가

### DIFF
--- a/src/main/java/org/kakaoshare/backend/common/util/RepositoryUtils.java
+++ b/src/main/java/org/kakaoshare/backend/common/util/RepositoryUtils.java
@@ -14,7 +14,7 @@ import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import io.jsonwebtoken.lang.Collections;
 import org.kakaoshare.backend.common.vo.PriceRange;
-import org.kakaoshare.backend.common.vo.Date;
+import org.kakaoshare.backend.common.vo.date.Date;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,9 +22,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.StringUtils;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
 public final class RepositoryUtils {

--- a/src/main/java/org/kakaoshare/backend/common/vo/date/Date.java
+++ b/src/main/java/org/kakaoshare/backend/common/vo/date/Date.java
@@ -3,10 +3,15 @@ package org.kakaoshare.backend.common.vo.date;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import org.kakaoshare.backend.common.vo.date.exception.DateException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+
+import static org.kakaoshare.backend.common.vo.date.exception.DateErrorCode.INVALID_END_DATE;
+import static org.kakaoshare.backend.common.vo.date.exception.DateErrorCode.INVALID_RANGE;
+import static org.kakaoshare.backend.common.vo.date.exception.DateErrorCode.NOT_FOUND_DATE;
 
 @EqualsAndHashCode
 @Getter
@@ -31,15 +36,15 @@ public abstract class Date {
 
     private void validateDateRange(final LocalDate startDate, final LocalDate endDate) {
         if (startDate == null && endDate == null) {
-            throw new IllegalArgumentException();
+            throw new DateException(NOT_FOUND_DATE);
         }
 
         if (endDate.isAfter(LocalDate.now())) {
-            throw new IllegalArgumentException();
+            throw new DateException(INVALID_END_DATE);
         }
 
         if (endDate.isBefore(startDate)) {
-            throw new IllegalArgumentException();
+            throw new DateException(INVALID_RANGE);
         }
     }
 }

--- a/src/main/java/org/kakaoshare/backend/common/vo/date/Date.java
+++ b/src/main/java/org/kakaoshare/backend/common/vo/date/Date.java
@@ -1,4 +1,4 @@
-package org.kakaoshare.backend.common.vo;
+package org.kakaoshare.backend.common.vo.date;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/src/main/java/org/kakaoshare/backend/common/vo/date/exception/DateErrorCode.java
+++ b/src/main/java/org/kakaoshare/backend/common/vo/date/exception/DateErrorCode.java
@@ -1,0 +1,20 @@
+package org.kakaoshare.backend.common.vo.date.exception;
+
+import lombok.Getter;
+import org.kakaoshare.backend.common.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum DateErrorCode implements ErrorCode {
+    INVALID_END_DATE(HttpStatus.BAD_REQUEST, "조회 마감 기간이 잘못되었습니다."),
+    NOT_FOUND_DATE(HttpStatus.NOT_FOUND, "조회 시작, 마감 기간은 필수입니다."),
+    INVALID_RANGE(HttpStatus.BAD_REQUEST, "조회 마감 기간은 시작 기간 이후여야 합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    DateErrorCode(final HttpStatus httpStatus, final String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/common/vo/date/exception/DateException.java
+++ b/src/main/java/org/kakaoshare/backend/common/vo/date/exception/DateException.java
@@ -1,0 +1,10 @@
+package org.kakaoshare.backend.common.vo.date.exception;
+
+import org.kakaoshare.backend.common.error.ErrorCode;
+import org.kakaoshare.backend.common.error.exception.BusinessException;
+
+public class DateException extends BusinessException {
+    public DateException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingDetailRepositoryCustom.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingDetailRepositoryCustom.java
@@ -1,6 +1,6 @@
 package org.kakaoshare.backend.domain.funding.repository.query;
 
-import org.kakaoshare.backend.common.vo.Date;
+import org.kakaoshare.backend.common.vo.date.Date;
 import org.kakaoshare.backend.domain.funding.dto.inquiry.ContributedFundingHistoryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingDetailRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/query/FundingDetailRepositoryCustomImpl.java
@@ -3,7 +3,7 @@ package org.kakaoshare.backend.domain.funding.repository.query;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.kakaoshare.backend.common.vo.Date;
+import org.kakaoshare.backend.common.vo.date.Date;
 import org.kakaoshare.backend.domain.funding.dto.inquiry.ContributedFundingHistoryResponse;
 import org.kakaoshare.backend.domain.funding.dto.inquiry.QContributedFundingHistoryDto;
 import org.kakaoshare.backend.domain.funding.dto.inquiry.QContributedFundingHistoryResponse;

--- a/src/main/java/org/kakaoshare/backend/domain/funding/vo/FundingHistoryDate.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/vo/FundingHistoryDate.java
@@ -1,6 +1,6 @@
 package org.kakaoshare.backend.domain.funding.vo;
 
-import org.kakaoshare.backend.common.vo.Date;
+import org.kakaoshare.backend.common.vo.date.Date;
 
 import java.time.LocalDate;
 

--- a/src/main/java/org/kakaoshare/backend/domain/order/vo/OrderHistoryDate.java
+++ b/src/main/java/org/kakaoshare/backend/domain/order/vo/OrderHistoryDate.java
@@ -1,6 +1,6 @@
 package org.kakaoshare.backend.domain.order.vo;
 
-import org.kakaoshare.backend.common.vo.Date;
+import org.kakaoshare.backend.common.vo.date.Date;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;

--- a/src/test/java/org/kakaoshare/backend/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/order/service/OrderServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kakaoshare.backend.common.dto.PageResponse;
+import org.kakaoshare.backend.common.vo.date.exception.DateException;
 import org.kakaoshare.backend.domain.option.dto.OptionSummaryResponse;
 import org.kakaoshare.backend.domain.option.repository.OptionDetailRepository;
 import org.kakaoshare.backend.domain.order.dto.inquiry.OrderHistoryDetailDto;
@@ -24,7 +25,11 @@ import org.kakaoshare.backend.domain.product.repository.ProductRepository;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -135,7 +140,7 @@ class OrderServiceTest {
         final OrderHistoryRequest orderHistoryRequest = new OrderHistoryRequest(startDate, endDate);
         final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdAt"));
         assertThatThrownBy(() -> orderService.lookUp(providerId, orderHistoryRequest, pageable))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(DateException.class);
     }
 
     @Test
@@ -146,7 +151,7 @@ class OrderServiceTest {
         final OrderHistoryRequest orderHistoryRequest = new OrderHistoryRequest(startDate, endDate);
         final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdAt"));
         assertThatThrownBy(() -> orderService.lookUp(providerId, orderHistoryRequest, pageable))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(DateException.class);
     }
 
     @Test
@@ -157,7 +162,7 @@ class OrderServiceTest {
         final OrderHistoryRequest orderHistoryRequest = new OrderHistoryRequest(startDate, endDate);
         final Pageable pageable = PageRequest.of(0, 5, Sort.by("createdAt"));
         assertThatThrownBy(() -> orderService.lookUp(providerId, orderHistoryRequest, pageable))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(DateException.class);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

close #257 

## 📝작업 내용
- `DateException`, `DateErrorCode` 추가
- `Date.validateDateRange()` 커스텀 예외 추가

## ✅테스트 결과
### Controller
__조회 마감 기간이 미래인 경우__
<img width="1057" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/baecdfc6-2a71-4a0a-be57-a3ef4f56438b">

__기간 범위가 잘못된 경우__
<img width="1078" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/e59583e3-0535-40e2-9f1c-1d45c44de3d0">

__기간이 없는 경우__
<img width="1069" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/c2331d35-8b74-4bff-a52f-e631c6f00cd1">

### Service
<img width="769" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/b181bcdf-9e61-4efe-8c69-d4e4774a9bd0">
