### PR TITLE
[HOTFIX] 로그인시 중복 회원가입 오류 해결

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/member/entity/Member.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package org.kakaoshare.backend.domain.member.entity;
 
+import com.querydsl.core.util.StringUtils;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -69,6 +70,14 @@ public class Member extends BaseTimeEntity {
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.providerId = providerId;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateProfileUrl(final String profileImageUrl) {
+        if (StringUtils.isNullOrEmpty(profileImageUrl) || this.profileImageUrl.equals(profileImageUrl)) {
+            return;
+        }
+
         this.profileImageUrl = profileImageUrl;
     }
 

--- a/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/OAuthService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/member/service/oauth/OAuthService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -94,7 +95,15 @@ public class OAuthService {
     }
 
     private UserDetails addOrFindByProfile(final OAuthProfile oAuthProfile) {
-        final Member member = memberRepository.save(oAuthProfile.toEntity());   // TODO: 5/27/24 dirty checking 을 통해 DB내 Member 테이블 프로필 사진 수정
+        final String providerId = oAuthProfile.getProviderId();
+        final Optional<Member> optionalMember = memberRepository.findMemberByProviderId(providerId);
+        if (optionalMember.isEmpty()) {
+            final Member member = memberRepository.save(oAuthProfile.toEntity());
+            return MemberDetails.from(member);
+        }
+
+        final Member member = optionalMember.get();
+        member.updateProfileUrl(oAuthProfile.getProfileImageUrl());
         return MemberDetails.from(member);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #263

## 📝작업 내용
- 로그인 시 중복 회원가입 수정

## ✅테스트 결과
<img width="698" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/fd376179-d45a-4e74-9019-471e44859f06">

