### PR TITLE
Fix/funding my item

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingRepository.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/repository/FundingRepository.java
@@ -21,5 +21,5 @@ public interface FundingRepository extends JpaRepository<Funding, Long>, Funding
     @Query("SELECT f FROM Funding f WHERE f.member.memberId IN :memberIds AND f.status = :status")
     List<Funding> findActiveFundingItemsByMemberIds(List<Long> memberIds, String status);
     @Query("SELECT f FROM Funding f WHERE f.member.memberId = :memberId AND f.status = :status")
-    Optional<Funding> findByMemberIdAndStatus(@Param("memberId") Long memberId, @Param("status") String status);
+    Optional<Funding> findByMemberIdAndStatus(@Param("memberId") Long memberId, @Param("status") FundingStatus status);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
@@ -78,7 +78,7 @@ public class FundingService {
 
     public ProgressResponse getMyFundingProgress(String providerId) {
         Member member = findMemberByProviderId(providerId);
-        Funding funding = fundingRepository.findByMemberIdAndStatus(member.getMemberId(), PROGRESS_STATUS)
+        Funding funding = fundingRepository.findByMemberIdAndStatus(member.getMemberId(), FundingStatus.PROGRESS)
                 .orElseThrow(() -> new FundingException(FundingErrorCode.NOT_FOUND));
 
         return getFundingProgress(funding.getFundingId(), member.getMemberId());
@@ -123,7 +123,7 @@ public class FundingService {
 
     public ProgressResponse checkFundingItem(FundingCheckRequest fundingCheckRequest) {
         Member member = findMemberByProviderId(fundingCheckRequest.getProviderId());
-        Funding funding = fundingRepository.findByMemberIdAndStatus(member.getMemberId(), PROGRESS_STATUS)
+        Funding funding = fundingRepository.findByMemberIdAndStatus(member.getMemberId(), FundingStatus.PROGRESS)
                 .orElseThrow(() -> new FundingException(FundingErrorCode.NOT_FOUND));
 
         return getFundingProgress(funding.getFundingId(), member.getMemberId());

--- a/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingServiceTest.java
@@ -8,6 +8,7 @@ import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
 import org.kakaoshare.backend.domain.funding.dto.RegisterRequest;
 import org.kakaoshare.backend.domain.funding.dto.RegisterResponse;
 import org.kakaoshare.backend.domain.funding.entity.Funding;
+import org.kakaoshare.backend.domain.funding.entity.FundingStatus;
 import org.kakaoshare.backend.domain.funding.repository.FundingRepository;
 import org.kakaoshare.backend.domain.member.entity.Member;
 import org.kakaoshare.backend.domain.member.repository.MemberRepository;
@@ -25,6 +26,8 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.BDDMockito.*;
 
 
@@ -81,5 +84,19 @@ public class FundingServiceTest {
 
         verify(memberRepository).findMemberByProviderId(member.getProviderId());
     }
+    @Test
+    @DisplayName("나의 등록된 펀딩아이템 조회")
+    public void testGetMyFundingProgress_WithValidData() {
+        Brand brand = BrandFixture.EDIYA.생성(1L);
+        Member member = MemberFixture.KAKAO.생성();
+        Product product = ProductFixture.TEST_PRODUCT.생성(1L, brand);
+        Funding funding = FundingFixture.SAMPLE_FUNDING.생성(1L, member, product);
 
+        when(memberRepository.findMemberByProviderId(member.getProviderId())).thenReturn(Optional.of(member));
+        when(fundingRepository.findByMemberIdAndStatus(member.getMemberId(), FundingStatus.PROGRESS)).thenReturn(Optional.of(funding));
+        when(fundingRepository.findByIdAndMemberId(funding.getFundingId(),member.getMemberId())).thenReturn(Optional.of(funding));
+
+        ProgressResponse response = fundingService.getMyFundingProgress(member.getProviderId());
+        assertNotNull(response, "ProgressResponse should not be null");
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #274 

## 📝작업 내용

내가 등록한 펀딩아이템 조회 시 엔티티에는 Enum형태로 저장되지만 조회 시 String 값을 기준으로 조회하여 타입 불일치로 인한 에러 발생해서 수정했습니다. 

## ✅테스트 결과

<img width="342" alt="image" src="https://github.com/KakaoFunding/back-end/assets/93575221/ba7697c7-e8f4-463d-87a5-a253604eeaa8">




