### PR TITLE
친구의 펀딩아이템 조회시 불필요한 과정 삭제

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -51,12 +51,6 @@ public class FundingController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/funding/{fundingId}")
-    public ResponseEntity<?> getFundingProgress(@PathVariable Long fundingId, @LoggedInMember String providerId) {
-        ProgressResponse response = fundingService.getFundingItemProgress(fundingId, providerId);
-        return ResponseEntity.ok(response);
-    }
-
     @PostMapping("/funding/friendItem")
     public ResponseEntity<?> getFriendFundingProgress(@LoggedInMember String providerId, @RequestBody
     FriendFundingInquiryRequest inquiryRequest) {

--- a/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/FriendFundingInquiryRequest.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/dto/inquiry/FriendFundingInquiryRequest.java
@@ -6,6 +6,5 @@ import lombok.Getter;
 @Getter
 @Builder
 public class FriendFundingInquiryRequest {
-    private final Long fundingId;
     private final String friendProviderId;
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
@@ -91,8 +91,12 @@ public class FundingService {
     public ProgressResponse getFriendFundingProgress(String providerId, FriendFundingInquiryRequest inquiryRequest) {
         Member self = findMemberByProviderId(providerId);
         Member friend = findMemberByProviderId(inquiryRequest.getFriendProviderId()); //todo 친구 검증 메소드 추가해야함
-        Funding funding = findByIdAndMemberId(inquiryRequest.getFundingId(), friend.getMemberId());
-
+        Funding funding = fundingRepository.findByMemberIdAndStatus(friend.getMemberId(), FundingStatus.PROGRESS)
+                .orElse(null);
+        
+        if (funding == null) {
+            return new ProgressResponse();
+        }
         return getFundingProgress(funding.getFundingId(), friend.getMemberId());
     }
 

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
@@ -91,13 +91,9 @@ public class FundingService {
     public ProgressResponse getFriendFundingProgress(String providerId, FriendFundingInquiryRequest inquiryRequest) {
         Member self = findMemberByProviderId(providerId);
         Member friend = findMemberByProviderId(inquiryRequest.getFriendProviderId()); //todo 친구 검증 메소드 추가해야함
-        Funding funding = fundingRepository.findByMemberIdAndStatus(friend.getMemberId(), FundingStatus.PROGRESS)
-                .orElse(null);
-        
-        if (funding == null) {
-            return new ProgressResponse();
-        }
-        return getFundingProgress(funding.getFundingId(), friend.getMemberId());
+        return fundingRepository.findByMemberIdAndStatus(friend.getMemberId(), FundingStatus.PROGRESS)
+                .map(funding -> getFundingProgress(funding.getFundingId(), friend.getMemberId()))
+                .orElse(new ProgressResponse());
     }
 
     public PageResponse<?> getMyFilteredFundingProducts(String providerId, FundingStatus status,


### PR DESCRIPTION
## #️⃣연관된 이슈

close #286 

## 📝작업 내용

친구의 펀딩아이템 조회 시 fundingId를 클라이언트가 줘야하는 과정 삭제