### PR TITLE
Refactor/myfunding products

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/controller/FundingController.java
@@ -73,7 +73,7 @@ public class FundingController {
 
     @GetMapping("/members/funding/products")
     public ResponseEntity<?> getMyAllFundingProducts(@LoggedInMember String providerId,
-                                                     @RequestParam(name = "status", required = false, defaultValue = "PROGRESS") FundingStatus status,
+                                                     @RequestParam(name = "status", required = false) FundingStatus status,
                                                      @PageableDefault(size = FUNDING_DEFAULT_SIZE) final Pageable pageable) {
         PageResponse<?> response = fundingService.getMyFilteredFundingProducts(providerId, status, pageable);
         return ResponseEntity.ok(response);

--- a/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/funding/service/FundingServiceTest.java
@@ -1,9 +1,13 @@
 package org.kakaoshare.backend.domain.funding.service;
 
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.kakaoshare.backend.common.dto.PageResponse;
 import org.kakaoshare.backend.domain.brand.entity.Brand;
+import org.kakaoshare.backend.domain.funding.dto.FundingResponse;
 import org.kakaoshare.backend.domain.funding.dto.ProgressResponse;
 import org.kakaoshare.backend.domain.funding.dto.RegisterRequest;
 import org.kakaoshare.backend.domain.funding.dto.RegisterResponse;
@@ -24,6 +28,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -99,4 +108,36 @@ public class FundingServiceTest {
         ProgressResponse response = fundingService.getMyFundingProgress(member.getProviderId());
         assertNotNull(response, "ProgressResponse should not be null");
     }
+
+    @Test
+    @DisplayName("내가 등록했던 펀딩아이템 목록 조회")
+    public void testGetMyAllFundingItems() {
+        Pageable pageable = PageRequest.of(0, 5);
+        Brand brand = BrandFixture.EDIYA.생성(1L);
+        Member member = MemberFixture.KAKAO.생성();
+        Product product1 = ProductFixture.TEST_PRODUCT.생성(1L, brand);
+        Product product2 = ProductFixture.TEST_PRODUCT.생성(2L, brand);
+        Product product3 = ProductFixture.TEST_PRODUCT.생성(3L, brand);
+        Funding funding1 = FundingFixture.SAMPLE_FUNDING.생성(1L, member, product1, FundingStatus.COMPLETE);
+        Funding funding2 = FundingFixture.SAMPLE_FUNDING.생성(2L, member, product2, FundingStatus.PROGRESS);
+        Funding funding3 = FundingFixture.SAMPLE_FUNDING.생성(3L, member, product3, FundingStatus.CANCEL);
+
+        List<FundingResponse> fundingResponses = Arrays.asList(
+                FundingResponse.from(funding1),
+                FundingResponse.from(funding2),
+                FundingResponse.from(funding3)
+        );
+        Page<FundingResponse> fundingPage = new PageImpl<>(fundingResponses, pageable, fundingResponses.size());
+
+        when(memberRepository.findMemberByProviderId(member.getProviderId())).thenReturn(Optional.of(member));
+        when(fundingRepository.findFundingByMemberIdAndStatusWithPage(
+                eq(member.getMemberId()), nullable(FundingStatus.class), eq(pageable)))
+                .thenReturn(fundingPage);
+
+        PageResponse<?> response = fundingService.getMyFilteredFundingProducts(member.getProviderId(), null, pageable);
+
+        assertThat(response.getItems()).hasSize(3);
+        verify(fundingRepository).findFundingByMemberIdAndStatusWithPage(member.getMemberId(), null, pageable);
+    }
 }
+


### PR DESCRIPTION
## #️⃣연관된 이슈

close #289 

## 📝작업 내용

- 내가 등록했던 모든 펀딩아이템 조회 시 필터링에 필요한 값을 defaultValue로 "PROGRESS"을 넣어두어서 진행중인 상품만 나오는 걸 전체가 나오도록 수정
- 변경된 조건을 위해 쿼리문 분리 및 수정

## ✅테스트 결과

<img width="447" alt="image" src="https://github.com/KakaoFunding/back-end/assets/93575221/2bbf0f77-7431-461b-9aa5-0adbcf587b46">


