### PR TITLE
펀딩 등록 시 목표금액 검증 로직  추가

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/funding/exception/FundingErrorCode.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/exception/FundingErrorCode.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum FundingErrorCode implements ErrorCode {
     INVALID_ATTRIBUTE_AMOUNT(HttpStatus.BAD_REQUEST, "기여 금액이 잘못되었습니다."),
+    INVALID_GOAL_AMOUNT(HttpStatus.BAD_REQUEST, "목표 금액이 잘못되었습니다."),
+
     NOT_FOUND(HttpStatus.NOT_FOUND, "펀딩 내역을 찾을 수 없습니다."),
     INVALID_STATUS(HttpStatus.BAD_REQUEST,"올바른 펀딩의 상태 값이 아닙니다."),
     ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 등록된 펀딩 내역이 있습니다.");;

--- a/src/main/java/org/kakaoshare/backend/domain/funding/exception/FundingErrorCode.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/exception/FundingErrorCode.java
@@ -11,7 +11,8 @@ public enum FundingErrorCode implements ErrorCode {
 
     NOT_FOUND(HttpStatus.NOT_FOUND, "펀딩 내역을 찾을 수 없습니다."),
     INVALID_STATUS(HttpStatus.BAD_REQUEST,"올바른 펀딩의 상태 값이 아닙니다."),
-    ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 등록된 펀딩 내역이 있습니다.");;
+    GOAL_AMOUNT_EXCEEDS_PRODUCT_PRICE(HttpStatus.BAD_REQUEST, "목표 금액은 상품 금액을 초과할 수 없습니다."),
+    ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 등록된 펀딩 내역이 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
@@ -56,6 +56,8 @@ public class FundingService {
         Product product = findProductById(productId);
         Member member = findMemberByProviderId(providerId);
 
+        validateGoalAmount(request.goalAmount(), product.getPrice());
+
         List<FundingResponse> existingFundings = fundingRepository.findFundingListByMemberId(member.getMemberId());
         for (FundingResponse funding : existingFundings) {
             if (funding.getStatus().equals(PROGRESS_STATUS)) {
@@ -181,5 +183,13 @@ public class FundingService {
     private Funding findByIdAndMemberId(Long fundingId, Long memberId) {
         return fundingRepository.findByIdAndMemberId(fundingId, memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid fundingId"));
+    }
+
+    private void validateGoalAmount(Long goalAmount, Long productPrice) {
+        if (!goalAmount.equals(productPrice)) {
+            if (goalAmount < 100 || goalAmount > productPrice - 100) {
+                throw new FundingException(FundingErrorCode.INVALID_GOAL_AMOUNT);
+            }
+        }
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/funding/service/FundingService.java
@@ -186,10 +186,11 @@ public class FundingService {
     }
 
     private void validateGoalAmount(Long goalAmount, Long productPrice) {
-        if (!goalAmount.equals(productPrice)) {
-            if (goalAmount < 100 || goalAmount > productPrice - 100) {
-                throw new FundingException(FundingErrorCode.INVALID_GOAL_AMOUNT);
-            }
+        if (!goalAmount.equals(productPrice) && (goalAmount < 100 || goalAmount > productPrice - 100)) {
+            throw new FundingException(FundingErrorCode.INVALID_GOAL_AMOUNT);
+        }
+        if (goalAmount > productPrice){
+            throw new FundingException(FundingErrorCode.GOAL_AMOUNT_EXCEEDS_PRODUCT_PRICE);
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #292 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 펀딩 등록 시 예외검증 기능 추가 

## ✅테스트 결과
<img width="460" alt="image" src="https://github.com/KakaoFunding/back-end/assets/93575221/66297e86-9b89-4d26-a94b-7b88e407992f">

