### PR TITLE
[HOTFIX]선물함 조회 쿼리 수정

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/gift/repository/query/GiftRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/gift/repository/query/GiftRepositoryCustomImpl.java
@@ -90,7 +90,7 @@ public class GiftRepositoryCustomImpl implements GiftRepositoryCustom {
                 .leftJoin(gift.receipt, receipt)
                 .leftJoin(receipt.product, product)
                 .where(gift.status.eq(status)
-                        .and(receipt.recipient.memberId.eq(memberId)))
+                        .and(receipt.receiver.memberId.eq(memberId)))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 

--- a/src/main/java/org/kakaoshare/backend/domain/gift/repository/query/GiftRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/gift/repository/query/GiftRepositoryCustomImpl.java
@@ -98,8 +98,9 @@ public class GiftRepositoryCustomImpl implements GiftRepositoryCustom {
                 .select(gift.count())
                 .from(gift)
                 .where(gift.status.eq(status)
-                        .and(receipt.recipient.memberId.eq(memberId)));
+                        .and(receipt.receiver.memberId.eq(memberId)));
 
         return toPage(pageable, contentQuery, countQuery);
     }
+
 }

--- a/src/test/java/org/kakaoshare/backend/domain/gift/repository/GiftRepositoryTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/gift/repository/GiftRepositoryTest.java
@@ -58,7 +58,7 @@ public class GiftRepositoryTest {
         Long memberId = 1L;
         Pageable pageable = PageRequest.of(0, 20, Sort.by("createdAt"));
         final Page<GiftResponse> response = giftRepository.findGiftsByMemberIdAndStatus(memberId, NOT_USED, pageable);
-        assertThat(response.getNumberOfElements()).isEqualTo(5);
+        assertThat(response.getNumberOfElements()).isEqualTo(2);
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #293 

## 📝작업 내용

- receipt 엔티티의 컬럼명 변경으로 인한 쿼리 수정