### PR TITLE
[HOTFIX] 선물 조회 시 보낸 이의 선물내역을 보여주는 현상 해결

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/gift/dto/inquiry/history/GiftDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/gift/dto/inquiry/history/GiftDto.java
@@ -1,6 +1,7 @@
 package org.kakaoshare.backend.domain.gift.dto.inquiry.history;
 
 import com.querydsl.core.annotations.QueryProjection;
+import org.kakaoshare.backend.domain.gift.entity.Gift;
 import org.kakaoshare.backend.domain.product.dto.ProductDto;
 
 import java.time.LocalDateTime;
@@ -14,5 +15,16 @@ public record GiftDto(Long giftId,
 
     @QueryProjection
     public GiftDto {
+    }
+
+    public static GiftDto from(final Gift gift) {
+        return new GiftDto(
+                gift.getGiftId(),
+                gift.getExpiredAt(),
+                gift.getCreatedAt(),
+                gift.getReceipt().getRecipient().getName(),
+                gift.getReceipt().getRecipient().getProviderId(),
+                ProductDto.from(gift.getReceipt().getProduct())
+        );
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/gift/repository/query/GiftRepositoryCustomImpl.java
+++ b/src/main/java/org/kakaoshare/backend/domain/gift/repository/query/GiftRepositoryCustomImpl.java
@@ -11,6 +11,7 @@ import org.kakaoshare.backend.domain.gift.entity.Gift;
 import org.kakaoshare.backend.domain.gift.entity.GiftStatus;
 import org.kakaoshare.backend.domain.gift.exception.GiftErrorCode;
 import org.kakaoshare.backend.domain.gift.exception.GiftException;
+import org.kakaoshare.backend.domain.member.entity.QMember;
 import org.kakaoshare.backend.domain.product.dto.QProductDto;
 import org.kakaoshare.backend.domain.product.entity.Product;
 import org.kakaoshare.backend.domain.product.entity.ProductThumbnail;
@@ -28,7 +29,6 @@ import static org.kakaoshare.backend.common.util.RepositoryUtils.createOrderSpec
 import static org.kakaoshare.backend.common.util.RepositoryUtils.eqExpression;
 import static org.kakaoshare.backend.common.util.RepositoryUtils.toPage;
 import static org.kakaoshare.backend.domain.gift.entity.QGift.gift;
-import static org.kakaoshare.backend.domain.member.entity.QMember.member;
 import static org.kakaoshare.backend.domain.product.entity.QProduct.product;
 import static org.kakaoshare.backend.domain.receipt.entity.QReceipt.receipt;
 
@@ -36,6 +36,9 @@ import static org.kakaoshare.backend.domain.receipt.entity.QReceipt.receipt;
 @Repository
 @RequiredArgsConstructor
 public class GiftRepositoryCustomImpl implements GiftRepositoryCustom {
+    private static final QMember receiver = new QMember("receiver");
+    private static final QMember recipient = new QMember("recipient");
+
     private final JPAQueryFactory queryFactory;
 
     @Override
@@ -89,9 +92,10 @@ public class GiftRepositoryCustomImpl implements GiftRepositoryCustom {
                 .from(gift)
                 .innerJoin(gift.receipt, receipt)
                 .innerJoin(receipt.product, product)
-                .innerJoin(receipt.recipient, member)
+                .innerJoin(receipt.recipient, recipient)
+                .innerJoin(receipt.receiver, receiver)
                 .where(
-                        eqExpression(receipt.recipient.providerId, providerId),
+                        eqExpression(receiver.providerId, providerId),
                         eqExpression(gift.status, status)
                 );
     }
@@ -126,8 +130,8 @@ public class GiftRepositoryCustomImpl implements GiftRepositoryCustom {
                 gift.giftId,
                 gift.expiredAt,
                 gift.createdAt,
-                member.name,
-                member.providerId,
+                recipient.name,
+                recipient.providerId,
                 getProductDto()
         );
     }

--- a/src/main/java/org/kakaoshare/backend/domain/product/dto/ProductDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/product/dto/ProductDto.java
@@ -1,10 +1,14 @@
 package org.kakaoshare.backend.domain.product.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import org.kakaoshare.backend.domain.product.entity.Product;
 
 @Getter
+@EqualsAndHashCode(callSuper = false)
+@ToString
 public class ProductDto {
     protected final Long productId;
     protected final String name;


### PR DESCRIPTION
## #️⃣연관된 이슈

close #308 

## 📝작업 내용
- `GiftRepositoryCustomImpl.createHistoryBaseQuery()` 조인 대상 변경
  - 보낸 이 (`Recipient`), 받는 이 (`Receiver`) 과 모두 Join하도록 수정
    - 보낸이 : 응답값에 사용
    - 받는이: `where`절에서 사용 

기존 선물내역 조회 SQL 문에서 Join 대상이 잘못되어 발생한 문제였습니다.


## ✅테스트 결과
### Repository
<img width="351" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/babc0af2-dd26-4e0a-8c8b-ea5534330be7">

### Controller
포스트맨 참고