### PR TITLE
[FEAT] metric 사용시 로깅을 사용하지 않는 로직 추가, favicon.ico 요청 허용

### DIFF
--- a/src/main/java/org/kakaoshare/backend/common/config/SecurityConfig.java
+++ b/src/main/java/org/kakaoshare/backend/common/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                                 .requestMatchers(ACTUATOR).permitAll()
                                 .requestMatchers(METRICS).permitAll()
+                                .requestMatchers(FAVICON_URL).permitAll()
                                 .requestMatchers(API_V_1 + "oauth/login").permitAll()
                                 .requestMatchers(API_V_1 + "oauth/logout").authenticated()
                                 .requestMatchers(API_V_1 + "oauth/reissue").permitAll()

--- a/src/main/java/org/kakaoshare/backend/logging/filter/LoggingFilter.java
+++ b/src/main/java/org/kakaoshare/backend/logging/filter/LoggingFilter.java
@@ -38,6 +38,9 @@ public class LoggingFilter extends OncePerRequestFilter {
     private static final String PARAM_DELIMITER = "&";
     private static final String KEY_VALUE_DELIMITER = "=";
 
+    private static final String METRIC_URL_PREFIX = "/actuator";
+    private static final String FAVICON_URL = "/favicon.ico";
+
     private final StopWatch apiTimer;
     private final ApiQueryCounter apiQueryCounter;
 
@@ -47,6 +50,10 @@ public class LoggingFilter extends OncePerRequestFilter {
                                     final FilterChain filterChain) throws ServletException, IOException {
         final ContentCachingRequestWrapper cachingRequest = new ContentCachingRequestWrapper(request);
         final ContentCachingResponseWrapper cachingResponse = new ContentCachingResponseWrapper(response);
+        final String requestURI = cachingRequest.getRequestURI();
+        if (requestURI.contains(METRIC_URL_PREFIX) || requestURI.contains(FAVICON_URL)) {
+            return;
+        }
 
         apiTimer.start();
         filterChain.doFilter(cachingRequest, cachingResponse);


### PR DESCRIPTION
## #️⃣연관된 이슈

close #315

## 📝작업 내용
- `LoggingFilter` 에 `/actuator`, `/favicon.ico` URL 요청에 대해 로깅하지 않도록 설정
- `/favicon.ico` 요청에 대해 `permitAll()` 설정

## ✅테스트 결과
<img width="2798" alt="image" src="https://github.com/KakaoFunding/back-end/assets/107420002/149b8456-ab8e-4de2-ab69-9cace2fc87dc">