### PR TITLE
[HOTFIX]ReceiptOption 엔티티가 BaseTimeEntity를 상속받도록 수정

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/receipt/entity/ReceiptOption.java
+++ b/src/main/java/org/kakaoshare/backend/domain/receipt/entity/ReceiptOption.java
@@ -20,9 +20,9 @@ import org.kakaoshare.backend.domain.base.entity.BaseTimeEntity;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
-        indexes = {@Index(name = "idx_receipt_option_receipt_id",columnList = "receipt_id",unique = true)}
+        indexes = {@Index(name = "idx_receipt_option_receipt_id", columnList = "receipt_id", unique = false)}
 )
-public class ReceiptOption {
+public class ReceiptOption extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## #️⃣연관된 이슈

close #320

## 📝작업 내용
- `ReceiptOption` 테이블이 `BaseTimeEnttiy`를 상속받도록 수정