### PR TITLE
[fix]응답 객체 수정 (#326)

### DIFF
--- a/src/main/java/org/kakaoshare/backend/domain/cart/dto/inquiry/CartResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/cart/dto/inquiry/CartResponse.java
@@ -21,6 +21,7 @@ public class CartResponse {
     private String optionName;
     private String optionDetailName;
     private Long totalPrice;
+    private boolean isSelected;
 
     public static CartResponse from(Cart cart){
         Long totalPrice = cart.calculateTotalPrice();
@@ -38,6 +39,7 @@ public class CartResponse {
                 .totalPrice(totalPrice)
                 .optionName(cart.getOption() != null ? cart.getOption().getName() : null)
                 .optionDetailName(cart.getOptionDetail() != null ? cart.getOptionDetail().getName() : null)
+                .isSelected(cart.isSelected())
                 .build();
     }
 }


### PR DESCRIPTION
장바구니 조회 요청시 체크 여부를 응답 객체에 추가

## #️⃣연관된 이슈

close #326 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 장바구니 조회시 체크 여부를 응답객체에 추가
  - 이를 통해 장바구니 체크 여부를 사용자가 확인 가능
## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

- ![image](https://github.com/KakaoFunding/back-end/assets/88381563/9e7aa35d-834b-42d3-8054-4d4c84dbfb41) `selected` 필드 확인
