### PR TITLE
카테고리 조회 성능 개선

### DIFF
--- a/src/main/java/org/kakaoshare/backend/common/config/RedisConfig.java
+++ b/src/main/java/org/kakaoshare/backend/common/config/RedisConfig.java
@@ -1,13 +1,17 @@
 package org.kakaoshare.backend.common.config;
 
+import static org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.CacheKeyPrefix;
@@ -19,11 +23,9 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import java.time.Duration;
-
-import static org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
 
 @Configuration
+@EnableCaching
 public class RedisConfig {
     private static final long DEFAULT_CACHE_DURATION = 1L;
 

--- a/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
@@ -1,14 +1,15 @@
 package org.kakaoshare.backend.domain.category.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import lombok.Builder;
-import lombok.Getter;
-import org.kakaoshare.backend.domain.category.entity.Category;
-
+import com.querydsl.core.annotations.QueryProjection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import lombok.Builder;
+import lombok.Getter;
+import org.kakaoshare.backend.domain.category.entity.Category;
 
 @Getter
 @JsonSerialize
@@ -20,18 +21,28 @@ public class CategoryDto {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final Long parentId;
     
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(Include.NON_EMPTY)
     private final List<CategoryDto> subCategories = new ArrayList<>();
-    private final TabType defaultTab;
+
+    private final TabType defaultTab=TabType.BRAND;
     private int level;
-    
-    
+
     @Builder
+    @QueryProjection
+    public CategoryDto(Long categoryId, String categoryName, Long parentId, List<CategoryDto> subCategories) {
+        this.categoryId = categoryId;
+        this.categoryName = categoryName;
+        this.parentId = parentId;
+        this.subCategories.addAll(subCategories);
+        this.level = 1;
+    }
+
+    @QueryProjection
     public CategoryDto(Long categoryId, String categoryName, Long parentId) {
         this.categoryId = categoryId;
         this.categoryName = categoryName;
         this.parentId = parentId;
-        this.defaultTab = TabType.BRAND;//브랜드를 조회하는것이 화면 로딩과정에서 쿼리를 최소화 가능해보임
+        this.level = 2;
     }
 
     public static CategoryDto from(final Category category) {

--- a/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryDto.java
@@ -6,35 +6,31 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.querydsl.core.annotations.QueryProjection;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import lombok.Builder;
 import lombok.Getter;
-import org.kakaoshare.backend.domain.category.entity.Category;
+import lombok.NoArgsConstructor;
 
 @Getter
 @JsonSerialize
+@NoArgsConstructor
 public class CategoryDto {
     public static final long PARENT_ID = -1L;
-    private final Long categoryId;
-    private final String categoryName;
+    private Long categoryId;
+    private String categoryName;
     
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private final Long parentId;
+    private Long parentId;
     
     @JsonInclude(Include.NON_EMPTY)
     private final List<CategoryDto> subCategories = new ArrayList<>();
 
     private final TabType defaultTab=TabType.BRAND;
-    private int level;
 
-    @Builder
     @QueryProjection
     public CategoryDto(Long categoryId, String categoryName, Long parentId, List<CategoryDto> subCategories) {
         this.categoryId = categoryId;
         this.categoryName = categoryName;
         this.parentId = parentId;
         this.subCategories.addAll(subCategories);
-        this.level = 1;
     }
 
     @QueryProjection
@@ -42,31 +38,6 @@ public class CategoryDto {
         this.categoryId = categoryId;
         this.categoryName = categoryName;
         this.parentId = parentId;
-        this.level = 2;
-    }
-
-    public static CategoryDto from(final Category category) {
-        CategoryDto categoryDto = CategoryDto
-                .getCategoryDtoBuilder(category)
-                .build();
-
-        giveLevelAndSubCategories(categoryDto, category);
-
-        return categoryDto;
-    }
-
-    private static void giveLevelAndSubCategories(CategoryDto dto, Category category) {
-        dto.level=2;
-        if (!category.isChildEmpty()) {
-            dto.level = 1;
-            dto.getSubCategories().addAll(getChildrenDtos(category));
-        }
-    }
-    
-    private static List<CategoryDto> getChildrenDtos(final Category category) {
-        return category.getChildren().stream()
-                .map(CategoryDto::from)
-                .toList();
     }
     
     @Override
@@ -80,17 +51,5 @@ public class CategoryDto {
                         .toList() +
                 ", defaultTab=" + defaultTab +
                 '}';
-    }
-
-    private static CategoryDtoBuilder getCategoryDtoBuilder(final Category category) {
-        Long parentId = Optional
-                .ofNullable(category.getParent())
-                .map(Category::getCategoryId)
-                .orElse(null);
-
-        return CategoryDto.builder()
-                .categoryId(category.getCategoryId())
-                .categoryName(category.getName())
-                .parentId(parentId);
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryHeaderResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryHeaderResponse.java
@@ -4,13 +4,15 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class CategoryHeaderResponse {
-    private final Long brandCount;
-    private final Long productCount;
-    private final Long totalCount;
-    private final List<SimpleCategoryDto> simpleCategoryDtos;
+    private Long brandCount;
+    private Long productCount;
+    private Long totalCount;
+    private List<SimpleCategoryDto> simpleCategoryDtos;
     @Builder
     private CategoryHeaderResponse(final Long brandCount, final Long productCount, Long totalCount, final List<SimpleCategoryDto> simpleCategoryDtos) {
         this.brandCount = brandCount;

--- a/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryHeaderResponse.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/dto/CategoryHeaderResponse.java
@@ -1,5 +1,6 @@
 package org.kakaoshare.backend.domain.category.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,20 +8,15 @@ import java.util.List;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class CategoryHeaderResponse {
     private Long brandCount;
     private Long productCount;
     private Long totalCount;
     private List<SimpleCategoryDto> simpleCategoryDtos;
-    @Builder
-    private CategoryHeaderResponse(final Long brandCount, final Long productCount, Long totalCount, final List<SimpleCategoryDto> simpleCategoryDtos) {
-        this.brandCount = brandCount;
-        this.productCount = productCount;
-        this.totalCount = totalCount;
-        this.simpleCategoryDtos = simpleCategoryDtos;
-    }
-    
+
     public static CategoryHeaderResponse of(final Long brandCount, final Long productCount, final List<SimpleCategoryDto> simpleCategoryDtos){
         return CategoryHeaderResponse
                 .builder()

--- a/src/main/java/org/kakaoshare/backend/domain/category/dto/SimpleCategoryDto.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/dto/SimpleCategoryDto.java
@@ -1,23 +1,27 @@
 package org.kakaoshare.backend.domain.category.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 import lombok.Getter;
-import org.kakaoshare.backend.domain.category.entity.Category;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class SimpleCategoryDto {
-    private final Long categoryId;
-    private final String categoryName;
+    private Long categoryId;
+    private String categoryName;
+
     @Builder
-    private SimpleCategoryDto(Long categoryId, String categoryName) {
+    @QueryProjection
+    public SimpleCategoryDto(Long categoryId, String categoryName) {
         this.categoryId = categoryId;
         this.categoryName = categoryName;
     }
-    
-    public static SimpleCategoryDto from(final Category category){
+
+    public static SimpleCategoryDto from(final CategoryDto categoryDto) {
         return SimpleCategoryDto.builder()
-                .categoryId(category.getCategoryId())
-                .categoryName(category.getName())
+                .categoryId(categoryDto.getCategoryId())
+                .categoryName(categoryDto.getCategoryName())
                 .build();
     }
 }

--- a/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/entity/Category.java
@@ -30,30 +30,33 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(
-        indexes = {@Index(name = "idx_category_parent_id",columnList = "parent_id")}
+        indexes = {
+                @Index(name = "idx_category_parent_id", columnList = "parent_id"),
+                @Index(name = "idx_category_id_parent_id", columnList = "category_id, parent_id")
+        }
 )
 public class Category extends BaseTimeEntity {
-    
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")
     private Long categoryId;
-    
+
     @Column(nullable = false)
     private String name;
-    
+
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "parent_id", referencedColumnName = "category_id")
     private Category parent;
-    
+
     @BatchSize(size = 100)//TODO 2024 02 26 21:15:10 : 추후 부모 카테고리당 자식 카테고리 수에 따라 결정하여 최적화
     @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Category> children;
-    
+
     public boolean isChildEmpty() {
         return children.isEmpty();
     }
-    
+
     @Override
     public String toString() {
         return "Category{" +

--- a/src/main/java/org/kakaoshare/backend/domain/category/repository/query/CategoryRepositoryCustom.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/repository/query/CategoryRepositoryCustom.java
@@ -1,19 +1,20 @@
 package org.kakaoshare.backend.domain.category.repository.query;
 
-import org.kakaoshare.backend.domain.category.entity.Category;
-
 import java.util.List;
 import java.util.Optional;
+import org.kakaoshare.backend.domain.category.dto.CategoryDto;
+import org.kakaoshare.backend.domain.category.dto.SimpleCategoryDto;
 
 public interface CategoryRepositoryCustom {
+
+    Optional<CategoryDto> findParentCategoryWithChildren(Long categoryId);
     
-    Optional<Category> findParentCategoryWithChildren(Long categoryId);
-    
-    Optional<Category> findChildCategoryWithParentCheck(final Long categoryId, final Long subcategoryId);
+    Optional<CategoryDto> findChildCategoryWithParentCheck(final Long categoryId, final Long subcategoryId);
     
     
-    List<Category> findAllParentCategories();
+    List<CategoryDto> findAllParentCategories();
     Long countBrand(Long categoryId);
     Long countProduct(Long categoryId);
-    
+
+    List<SimpleCategoryDto> findChildrenCategory(Long categoryId);
 }

--- a/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
+++ b/src/main/java/org/kakaoshare/backend/domain/category/service/CategoryService.java
@@ -1,55 +1,45 @@
 package org.kakaoshare.backend.domain.category.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.kakaoshare.backend.domain.category.dto.CategoryDto;
 import org.kakaoshare.backend.domain.category.dto.CategoryHeaderResponse;
 import org.kakaoshare.backend.domain.category.dto.SimpleCategoryDto;
-import org.kakaoshare.backend.domain.category.entity.Category;
 import org.kakaoshare.backend.domain.category.error.CategoryErrorCode;
 import org.kakaoshare.backend.domain.category.error.exception.CategoryException;
 import org.kakaoshare.backend.domain.category.repository.CategoryRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CategoryService {
     private final CategoryRepository categoryRepository;
-    
-    //TODO 2024 03 31 21:33:04 : 캐싱 구현 후 캐싱된 쿼리 사용
+
+    @Cacheable(value = "parentCategories", key = "'all'", cacheManager = "cacheManager")
     public List<CategoryDto> getParentCategories() {
-        List<Category> categories = categoryRepository.findAllParentCategories();
-        return categories.stream()
-                .map(CategoryDto::from)
-                .toList();
+        return categoryRepository.findAllParentCategories();
     }
-    
-    //TODO 2024 03 31 21:32:45 : 캐싱 구현 후 캐싱된 쿼리 사용
+
+    @Cacheable(value = "parentCategory", key = "#categoryId", cacheManager = "cacheManager")
     public CategoryDto getParentCategory(final Long categoryId) {
-        Category category = categoryRepository.findParentCategoryWithChildren(categoryId)
+        return categoryRepository.findParentCategoryWithChildren(categoryId)
                 .orElseThrow(() -> new CategoryException(CategoryErrorCode.CATEGORY_NOT_FOUND));
-        return CategoryDto.from(category);
     }
-    
+
+    @Cacheable(value = "childCategory", key = "{#categoryId, #subcategoryId}", cacheManager = "cacheManager")
     public CategoryDto getChildCategory(final Long categoryId, final Long subcategoryId) {
-        Category category = categoryRepository.findChildCategoryWithParentCheck(categoryId, subcategoryId)
+        return categoryRepository.findChildCategoryWithParentCheck(categoryId, subcategoryId)
                 .orElseThrow(() -> new CategoryException(CategoryErrorCode.INVALID_SUB_CATEGORY_ID));
-        return CategoryDto.from(category);
     }
-    
-    //TODO 2024 03 31 21:32:16 : 캐싱 구현 후 캐싱된 쿼리 사용
+
+    @Cacheable(value = "categoryHeaderResponse", key = "#categoryId", cacheManager = "cacheManager")
     public CategoryHeaderResponse getHeaderResponse(final Long categoryId) {
         Long brandCount = categoryRepository.countBrand(categoryId);
         Long productCount = categoryRepository.countProduct(categoryId);
-        List<SimpleCategoryDto> list = categoryRepository.findParentCategoryWithChildren(categoryId)
-                .orElseThrow()
-                .getChildren()
-                .stream()
-                .map(SimpleCategoryDto::from)
-                .toList();
+        List<SimpleCategoryDto> list=categoryRepository.findChildrenCategory(categoryId);
         return CategoryHeaderResponse.of(brandCount, productCount, list);
     }
 }

--- a/src/main/resources/db/migration/V11__modify_category_index.sql
+++ b/src/main/resources/db/migration/V11__modify_category_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_category_id_parent_id ON category (category_id, parent_id);

--- a/src/test/java/org/kakaoshare/backend/domain/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/category/repository/CategoryRepositoryTest.java
@@ -1,18 +1,18 @@
 package org.kakaoshare.backend.domain.category.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Objects;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kakaoshare.backend.common.RepositoryTest;
+import org.kakaoshare.backend.domain.category.dto.CategoryDto;
 import org.kakaoshare.backend.domain.category.entity.Category;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.StopWatch;
-
-import java.util.List;
-import java.util.Objects;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @RepositoryTest
 class CategoryRepositoryTest {
@@ -84,12 +84,11 @@ class CategoryRepositoryTest {
     @DisplayName("루트 카테고리의 자식 카테고리는 부모 카테고리와 자식 카테고리가 있다")
     void testFirstGen() {
         stopWatch.start("first gen");
-        Category parent = categoryRepository.findParentCategoryWithChildren(PARENT_ID).orElseThrow();
+        CategoryDto parent = categoryRepository.findParentCategoryWithChildren(PARENT_ID).orElseThrow();
         stopWatch.stop();
         assertThat(parent).isNotNull();
-        assertThat(parent.getParent()).isNull();
-        assertThat(parent.getChildren()).isNotEmpty();
-        assertThat(parent.getChildren().size()).isEqualTo(5);
+        assertThat(parent.getSubCategories()).isNotEmpty();
+        assertThat(parent.getSubCategories().size()).isEqualTo(5);
         System.out.println(stopWatch.prettyPrint());
     }
     
@@ -97,11 +96,10 @@ class CategoryRepositoryTest {
     @DisplayName("말단 카테고리는 부모 카테고리는 있지만 자식 카테고리는 없다")
     void testSecondGen() {
         stopWatch.start("second gen");
-        Category child = categoryRepository.findChildCategoryWithParentCheck(PARENT_ID,CHILD_ID).orElseThrow();
+        CategoryDto child = categoryRepository.findChildCategoryWithParentCheck(PARENT_ID,CHILD_ID).orElseThrow();
         stopWatch.stop();
         assertThat(child).isNotNull();
-        assertThat(child.getParent()).isNotNull();
-        assertThat(child.getChildren()).isEmpty();
+        assertThat(child.getParentId()).isNotNull();
         System.out.println(stopWatch.prettyPrint());
     }
     

--- a/src/test/java/org/kakaoshare/backend/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/kakaoshare/backend/domain/category/service/CategoryServiceTest.java
@@ -1,5 +1,12 @@
 package org.kakaoshare.backend.domain.category.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,14 +17,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.util.StopWatch;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class CategoryServiceTest {
@@ -59,7 +58,7 @@ class CategoryServiceTest {
         // given
         Category parent = getParent();
         parent.getChildren().addAll(mockChildren(parent));
-        given(categoryRepository.findParentCategoryWithChildren(PARENT_ID)).willReturn(Optional.of(parent));
+        given(categoryRepository.findParentCategoryWithChildren(PARENT_ID)).willReturn(Optional.of(CategoryDto.from(parent)));
         
         
         CategoryDto category = categoryService.getParentCategory(PARENT_ID);
@@ -80,7 +79,8 @@ class CategoryServiceTest {
     @DisplayName("자식 카테고리는 자신의 자식 카테고리를 가지고 있지 않다")
     void testChildCategory() {
         Category child=mockChild();
-        given(categoryRepository.findChildCategoryWithParentCheck(PARENT_ID,CHILD_ID)).willReturn(Optional.of(child));
+//        given(categoryRepository.findChildCategoryWithParentCheck(PARENT_ID,CHILD_ID)).willReturn(Optional.of(child));
+        given(categoryRepository.findChildCategoryWithParentCheck(PARENT_ID,CHILD_ID)).willReturn(Optional.of(CategoryDto.from(child)));
         CategoryDto category = categoryService.getChildCategory(PARENT_ID, CHILD_ID);
         
         assertThat(category).isNotNull();


### PR DESCRIPTION
## #️⃣연관된 이슈

close #329

## 📝작업 내용

- 카테고리 조회 쿼리 개선
   - 인덱스 추가
   - projection 으로 쿼리 개선
- 카테고리 조회시 redis cache 적용

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

- [개선 시도 결과](https://yechan05.notion.site/d2c87bcd003d4d13b8dbecceab423185)

## 🙏리뷰 요구사항(선택)

mass가 큰 기능은 아니라 개선 작업이 많지는 않습니다만, 캐싱 가능성이 높은 쿼리들이 있어 캐싱으로 성능을 대폭 개선하였습니다
자세한 내용은 위의 notion 기록 확인해주시면 감사하겠습니다